### PR TITLE
feat: display push-to-start tokens per activity type

### DIFF
--- a/packages/ui-plugins/live-activities/src/api/profile.ts
+++ b/packages/ui-plugins/live-activities/src/api/profile.ts
@@ -134,6 +134,11 @@ export const getProfile = async ({
       }
     }
   );
+
+  if (!response.ok) {
+    throw new Error(`Profile fetch failed: ${response.status}`);
+  }
+  
   const data: ProfileApiResponse = await response.json();
   if (!Object.keys(data).length) {
     return null;

--- a/packages/ui-plugins/live-activities/src/components/validation/__tests__/live-activities-validation-section.test.tsx
+++ b/packages/ui-plugins/live-activities/src/components/validation/__tests__/live-activities-validation-section.test.tsx
@@ -19,7 +19,7 @@ vi.mock('../../../hooks/useClientInfo', () => ({
   useClientIOSVersion: vi.fn(),
   useClientLiveActivitiesSupport: vi.fn(),
   useClientDeviceType: vi.fn(),
-  useSelectedClientPushToStartToken: vi.fn(),
+  useActivitiesWithPushToStartTokens: vi.fn(),
 }));
 
 vi.mock('../../../hooks/useActivities', () => ({
@@ -35,7 +35,7 @@ vi.mock('../../../utils/clipboard', () => ({
 }));
 
 // Import mocked modules
-import { useClientIOSVersion, useClientLiveActivitiesSupport, useClientDeviceType, useSelectedClientPushToStartToken } from '../../../hooks/useClientInfo';
+import { useClientIOSVersion, useClientLiveActivitiesSupport, useClientDeviceType, useActivitiesWithPushToStartTokens } from '../../../hooks/useClientInfo';
 import { useLiveActivitiesData } from '../../../hooks/useActivities';
 import { useLiveActivitiesValidationStatus } from '../../../hooks/useLiveActivitiesValidationStatus';
 import { copyToClipboard } from '../../../utils/clipboard';
@@ -43,7 +43,7 @@ import { copyToClipboard } from '../../../utils/clipboard';
 const mockUseClientIOSVersion = useClientIOSVersion as ReturnType<typeof vi.fn>;
 const mockUseClientLiveActivitiesSupport = useClientLiveActivitiesSupport as ReturnType<typeof vi.fn>;
 const mockUseClientDeviceType = useClientDeviceType as ReturnType<typeof vi.fn>;
-const mockUseSelectedClientPushToStartToken = useSelectedClientPushToStartToken as ReturnType<typeof vi.fn>;
+const mockUseActivitiesWithPushToStartTokens = useActivitiesWithPushToStartTokens as ReturnType<typeof vi.fn>;
 const mockUseLiveActivitiesData = useLiveActivitiesData as ReturnType<typeof vi.fn>;
 const mockUseLiveActivitiesValidationStatus = useLiveActivitiesValidationStatus as ReturnType<typeof vi.fn>;
 const mockCopyToClipboard = copyToClipboard as ReturnType<typeof vi.fn>;
@@ -74,7 +74,7 @@ describe('LiveActivitiesValidationSection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCopyToClipboard.mockResolvedValue(undefined);
-    mockUseSelectedClientPushToStartToken.mockReturnValue('test-push-to-start-token');
+    mockUseActivitiesWithPushToStartTokens.mockReturnValue([]);
   });
 
   describe('Basic Support', () => {
@@ -157,6 +157,7 @@ describe('LiveActivitiesValidationSection', () => {
         registeredActivities: [],
         activeActivities: []
       });
+      mockUseActivitiesWithPushToStartTokens.mockReturnValue([]);
 
       render(
         <TestWrapper>
@@ -173,6 +174,85 @@ describe('LiveActivitiesValidationSection', () => {
       
       // Note: Column-specific tests would require TableView to render in test environment
       // The component is correctly structured to show push-to-start column for full support
+    });
+
+    it('should render push-to-start tokens for multiple activities in full support', () => {
+      const mockActivitiesWithTokens = [
+        {
+          attributeType: 'FoodDeliveryLiveActivityAttributes',
+          pushToStartToken: 'token-food-123',
+          hasSchema: true,
+          hasPushToStartToken: true,
+          lastUpdated: Date.now()
+        },
+        {
+          attributeType: 'RideShareLiveActivityAttributes',
+          pushToStartToken: 'token-ride-456',
+          hasSchema: true,
+          hasPushToStartToken: true,
+          lastUpdated: Date.now()
+        }
+      ];
+
+      mockUseClientIOSVersion.mockReturnValue('18.0');
+      mockUseClientLiveActivitiesSupport.mockReturnValue({
+        supportsLiveActivities: true,
+        supportsFrequentUpdates: true,
+        minimumOSVersion: '16.1'
+      });
+      mockUseClientDeviceType.mockReturnValue('iPhone');
+      mockUseLiveActivitiesValidationStatus.mockReturnValue(VALIDATION_STATUS.FULL_SUPPORT);
+      mockUseLiveActivitiesData.mockReturnValue({
+        activityTypes: mockActivityTypes,
+        registeredActivities: [],
+        activeActivities: []
+      });
+      mockUseActivitiesWithPushToStartTokens.mockReturnValue(mockActivitiesWithTokens);
+
+      render(
+        <TestWrapper>
+          <LiveActivitiesValidationSection />
+        </TestWrapper>
+      );
+
+      // Check that both activity types are mentioned in the labels
+      const foodActivityElements = screen.getAllByText(/FoodDeliveryLiveActivityAttributes/);
+      expect(foodActivityElements.length).toBeGreaterThan(0);
+      
+      const rideActivityElements = screen.getAllByText(/RideShareLiveActivityAttributes/);
+      expect(rideActivityElements.length).toBeGreaterThan(0);
+      
+      // Check that the actual tokens can be found in the document
+      expect(screen.getByText('token-food-123')).toBeInTheDocument();
+      expect(screen.getByText('token-ride-456')).toBeInTheDocument();
+    });
+
+    it('should show "Not Available" when no activities have push-to-start tokens in full support', () => {
+      mockUseClientIOSVersion.mockReturnValue('18.0');
+      mockUseClientLiveActivitiesSupport.mockReturnValue({
+        supportsLiveActivities: true,
+        supportsFrequentUpdates: true,
+        minimumOSVersion: '16.1'
+      });
+      mockUseClientDeviceType.mockReturnValue('iPhone');
+      mockUseLiveActivitiesValidationStatus.mockReturnValue(VALIDATION_STATUS.FULL_SUPPORT);
+      mockUseLiveActivitiesData.mockReturnValue({
+        activityTypes: mockActivityTypes,
+        registeredActivities: [],
+        activeActivities: []
+      });
+      mockUseActivitiesWithPushToStartTokens.mockReturnValue([]);
+
+      render(
+        <TestWrapper>
+          <LiveActivitiesValidationSection />
+        </TestWrapper>
+      );
+
+      // The component should render without errors when no tokens are available
+      // Check that full support status is still displayed
+      expect(screen.getByText('Full Live Activities Support')).toBeInTheDocument();
+      expect(screen.getByText('18.0')).toBeInTheDocument();
     });
   });
 

--- a/packages/ui-plugins/live-activities/src/components/validation/__tests__/profile-section-widget.test.tsx
+++ b/packages/ui-plugins/live-activities/src/components/validation/__tests__/profile-section-widget.test.tsx
@@ -145,7 +145,7 @@ describe('ProfileSectionWidget', () => {
       expect(screen.getByLabelText('Loading…')).toBeInTheDocument();
     });
 
-    it('should show loading spinner when profile data is missing', () => {
+    it('should not show loading spinner when isLoading is false even if data is missing', () => {
       mockUseProfile.mockReturnValue({
         data: null,
         isLoading: false
@@ -157,7 +157,7 @@ describe('ProfileSectionWidget', () => {
         </TestWrapper>
       );
 
-      expect(screen.getByLabelText('Loading…')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Loading…')).not.toBeInTheDocument();
     });
   });
 
@@ -283,7 +283,8 @@ describe('ProfileSectionWidget', () => {
         );
       }).not.toThrow();
 
-      expect(screen.getByLabelText('Loading…')).toBeInTheDocument();
+      // Component renders without loading spinner when data is null but isLoading is false
+      expect(screen.queryByLabelText('Loading…')).not.toBeInTheDocument();
     });
 
     it('should handle missing entity data gracefully', () => {
@@ -322,6 +323,9 @@ describe('ProfileSectionWidget', () => {
           </TestWrapper>
         );
       }).not.toThrow();
+      
+      // Component should render but without loading spinner
+      expect(screen.queryByLabelText('Loading…')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/ui-plugins/live-activities/src/components/validation/live-activities-validation-section.tsx
+++ b/packages/ui-plugins/live-activities/src/components/validation/live-activities-validation-section.tsx
@@ -35,7 +35,7 @@ import { TEST_IDS } from '../../constants/testIds';
 import { 
   useLiveActivitiesData
 } from '../../hooks/useActivities';
-import { useClientIOSVersion, useClientLiveActivitiesSupport, useClientDeviceType, useSelectedClientPushToStartToken } from '../../hooks/useClientInfo';
+import { useClientIOSVersion, useClientLiveActivitiesSupport, useClientDeviceType, useActivitiesWithPushToStartTokens } from '../../hooks/useClientInfo';
 import { useLiveActivitiesValidationStatus } from '../../hooks/useLiveActivitiesValidationStatus';
 import { createLiveActivitiesTableData } from '../../utils/liveActivitiesDisplay';
 import { getStatusDisplayConfig, isDeviceVersionBelowAppMinimum } from '../../utils/liveActivitiesValidation';
@@ -48,7 +48,7 @@ const LiveActivitiesValidationSection = () => {
   const liveActivitiesSupport = useClientLiveActivitiesSupport();
   const deviceType = useClientDeviceType();
   const liveActivities = useLiveActivitiesData();
-  const pushToStartToken = useSelectedClientPushToStartToken();
+  const activitiesWithPushToStartToken = useActivitiesWithPushToStartTokens();
 
   // Get status display configuration using utility function
   const statusConfig = getStatusDisplayConfig(validationStatus);
@@ -150,21 +150,26 @@ const LiveActivitiesValidationSection = () => {
 
       // Add PushToStart Token for iOS 17.1+ (full support only)
       if (validationStatus === VALIDATION_STATUS.FULL_SUPPORT) {
-        dataRows.push({
-          label: formatMessage(validationMessages.pushToStartToken),
-          value: pushToStartToken || formatMessage(validationMessages.notAvailable),
-          showCopy: !!pushToStartToken,
-          isLongData: true,
-          tooltip: pushToStartToken 
-            ? formatMessage(validationMessages.pushToStartTokenTooltip)
-            : formatMessage(validationMessages.pushToStartTokenTooltipNone)
-        });
+        if(activitiesWithPushToStartToken.length === 0) {
+          dataRows.push({
+            label: formatMessage(validationMessages.pushToStartToken),
+            value: formatMessage(validationMessages.notAvailable),
+            showCopy: false,
+            tooltip: formatMessage(validationMessages.pushToStartTokenTooltipNone)
+          });
+        } else {
+        activitiesWithPushToStartToken.forEach(activity => {
+          dataRows.push({
+            label: `${formatMessage(validationMessages.pushToStartToken)} - ${activity.attributeType}`,
+            value: activity.pushToStartToken || formatMessage(validationMessages.notAvailable),
+            showCopy: !!activity.pushToStartToken,
+            isLongData: true,
+            tooltip: formatMessage(validationMessages.pushToStartTokenTooltip)
+          });
+        })}
+        }
       }
     }
-
-
-  }
-
   // Get registered Live Activities table data (always show activities, push-to-start tokens only for iOS 17.1+)
   const registeredActivitiesTableData = (validationStatus === VALIDATION_STATUS.BASIC_SUPPORT || validationStatus === VALIDATION_STATUS.FULL_SUPPORT)
     ? createLiveActivitiesTableData(liveActivities.activityTypes, validationStatus)

--- a/packages/ui-plugins/live-activities/src/components/validation/profile-section-widget.tsx
+++ b/packages/ui-plugins/live-activities/src/components/validation/profile-section-widget.tsx
@@ -27,7 +27,7 @@ const ProfileSectionWidget: React.FC = () => {
   const profilePush = profile?.data?.entity?.pushNotificationDetails?.[0];
   const profilePushToStart = profile?.data?.entity?.liveActivityPushNotificationDetails?.[0];
   const validationStatus = useDataStreamValidationStatus();
-  const isLoading = profile.isLoading || !profile.data;
+  const isLoading = profile.isLoading;
   const profileId = profile?.data?.entityId;
 
   return (
@@ -49,7 +49,7 @@ const ProfileSectionWidget: React.FC = () => {
             </thead>
             <tbody>
               <KeyValueRow label="ECID">
-                {profile.data!.entity?.pushNotificationDetails?.[0]?.identity?.id || (
+                {profile.data?.entity?.pushNotificationDetails?.[0]?.identity?.id || (
                   <UnknownBadge />
                 )}
               </KeyValueRow>

--- a/packages/ui-plugins/live-activities/src/containers/activities.tsx
+++ b/packages/ui-plugins/live-activities/src/containers/activities.tsx
@@ -193,7 +193,7 @@ function Activities() {
             <Flex direction="row" justifyContent="end" alignItems="center">              
               {platform.hasLiveActivities && (
                 <Flex alignItems="center" gap="size-100">
-                  <LaunchLiveActivity />
+                  {platform.hasRemoteStart && <LaunchLiveActivity />}
                   <InfoButton />
                 </Flex>
               )}
@@ -214,7 +214,7 @@ function Activities() {
                 </Text>
                 {platform.hasLiveActivities && (
                   <Flex alignItems="center" gap="size-200" marginTop="size-200">
-                    <LaunchLiveActivity />
+                   {platform.hasRemoteStart && <LaunchLiveActivity />}
                     <InfoButton />
                   </Flex>
                 )}

--- a/packages/ui-plugins/live-activities/src/hooks/useClientInfo.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useClientInfo.ts
@@ -238,10 +238,20 @@ function useClientIOSVersion() {
   if (!selectedClientObj?.payload?.deviceInfo) return undefined;
 
   const operatingSystem = selectedClientObj.payload.deviceInfo['Operating system'];
-  if (!operatingSystem || !operatingSystem.startsWith('iOS ')) return undefined;
-
-  // Extract version from "iOS 18.0" -> "18.0"
-  return operatingSystem.replace('iOS ', '');
+  if (!operatingSystem) return undefined;
+  
+  // Handle both iOS and iPadOS
+  if (operatingSystem.startsWith('iOS ')) {
+    // Extract version from "iOS 18.0" -> "18.0"
+    return operatingSystem.replace('iOS ', '');
+  }
+  
+  if (operatingSystem.startsWith('iPadOS ')) {
+    // Extract version from "iPadOS 18.0" -> "18.0"
+    return operatingSystem.replace('iPadOS ', '');
+  }
+  
+  return undefined;
 }
 
 /**

--- a/packages/ui-plugins/live-activities/src/hooks/useClientInfo.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useClientInfo.ts
@@ -128,30 +128,6 @@ function useActivitiesWithPushToStartTokens(): RegisteredActivity[] {
   
     const registeredActivities = useRegisteredActivities();
   
-    /**
-     * {
-      "state.data": {
-          "pushidentifier": "803FB00A29938438240C8DF63140113D2070F42F7709B2A67167735C5897A47EE50C090A13BB927964D9995181D2069EB2A5A03162C5EB0107EA1F3C3A428CC2A87B26BA4D2FD16417F4E8AAA8D8644D",
-          "liveActivity": {
-              "pushToStartTokens": {
-                  "GameScoreLiveActivityAttributes": {
-                      "token": "80469f94715bd1f5b707c1450a88dcca079e3bc04532c8181652aef84f0584f60ac1d8030901633330a1421d015bff6e6a41afe8191553ca76546d16f53f569d84d8f2f347bd951e2bb31edf4560cb3a3d59a0ac6d0297605f8d7472e2c4589d5234b485df4253061a6ef7ee309c0698d718db9e43d32b3b5d0e887efa25419d",
-                      "firstIssued": 1765779189049.1628
-                  },
-                  "FoodDeliveryLiveActivityAttributes": {
-                      "token": "80469f94715bd1f5b707c1450a88dcca079e3bc04532c8181652aef84f0584f60ac1d8030901633330a1421d015bff6e6a41afe8191553ca76546d16f53f569d84d8f2f347bd951e2bb31edf4560cb3a3d59a0ac6d0297605f8d7472e2c4589d5234b485df4253061a6ef7ee309c0698d718db9e43d32b3b5d0e887efa25419d",
-                      "firstIssued": 1765779189049.155
-                  },
-                  "AirplaneTrackingAttributes": {
-                      "token": "80469f94715bd1f5b707c1450a88dcca079e3bc04532c8181652aef84f0584f60ac1d8030901633330a1421d015bff6e6a41afe8191553ca76546d16f53f569d84d8f2f347bd951e2bb31edf4560cb3a3d59a0ac6d0297605f8d7472e2c4589d5234b485df4253061a6ef7ee309c0698d718db9e43d32b3b5d0e887efa25419d",
-                      "firstIssued": 1765779189049.151
-                  }
-              }
-          }
-      }
-  }
-     * 
-     */
     const activitiesArrayWithPushToStartToken = registeredActivities.map(activity => {
       return {
         ...activity,

--- a/packages/ui-plugins/live-activities/src/hooks/useClientInfo.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useClientInfo.ts
@@ -1,4 +1,6 @@
 import { useEvents, useSelectedClients, useClients } from '@assurance/plugin-bridge-provider';
+import { useRegisteredActivities } from './useActivities';
+import { RegisteredActivity } from '../types/liveActivities';
 
 // Hook to extract the latest ECID (Experience Cloud ID) from shared state update events for the currently selected client.
 //
@@ -117,6 +119,47 @@ function useSelectedClientPushToStartToken() {
     events[0]?.payload?.metadata?.['state.data']?.liveActivity?.pushToStartToken;
   return pushToStartToken;
 }
+
+function useActivitiesWithPushToStartTokens(): RegisteredActivity[] {
+    const events = useEvents({
+      sorted: 'desc',
+      matchers: ["payload.ACPExtensionEventData.stateowner=='com.adobe.messaging'"]
+    });
+  
+    const registeredActivities = useRegisteredActivities();
+  
+    /**
+     * {
+      "state.data": {
+          "pushidentifier": "803FB00A29938438240C8DF63140113D2070F42F7709B2A67167735C5897A47EE50C090A13BB927964D9995181D2069EB2A5A03162C5EB0107EA1F3C3A428CC2A87B26BA4D2FD16417F4E8AAA8D8644D",
+          "liveActivity": {
+              "pushToStartTokens": {
+                  "GameScoreLiveActivityAttributes": {
+                      "token": "80469f94715bd1f5b707c1450a88dcca079e3bc04532c8181652aef84f0584f60ac1d8030901633330a1421d015bff6e6a41afe8191553ca76546d16f53f569d84d8f2f347bd951e2bb31edf4560cb3a3d59a0ac6d0297605f8d7472e2c4589d5234b485df4253061a6ef7ee309c0698d718db9e43d32b3b5d0e887efa25419d",
+                      "firstIssued": 1765779189049.1628
+                  },
+                  "FoodDeliveryLiveActivityAttributes": {
+                      "token": "80469f94715bd1f5b707c1450a88dcca079e3bc04532c8181652aef84f0584f60ac1d8030901633330a1421d015bff6e6a41afe8191553ca76546d16f53f569d84d8f2f347bd951e2bb31edf4560cb3a3d59a0ac6d0297605f8d7472e2c4589d5234b485df4253061a6ef7ee309c0698d718db9e43d32b3b5d0e887efa25419d",
+                      "firstIssued": 1765779189049.155
+                  },
+                  "AirplaneTrackingAttributes": {
+                      "token": "80469f94715bd1f5b707c1450a88dcca079e3bc04532c8181652aef84f0584f60ac1d8030901633330a1421d015bff6e6a41afe8191553ca76546d16f53f569d84d8f2f347bd951e2bb31edf4560cb3a3d59a0ac6d0297605f8d7472e2c4589d5234b485df4253061a6ef7ee309c0698d718db9e43d32b3b5d0e887efa25419d",
+                      "firstIssued": 1765779189049.151
+                  }
+              }
+          }
+      }
+  }
+     * 
+     */
+    const activitiesArrayWithPushToStartToken = registeredActivities.map(activity => {
+      return {
+        ...activity,
+        pushToStartToken: events[0]?.payload?.metadata?.['state.data']?.liveActivity?.pushToStartTokens?.[activity.attributeType]?.token
+      };
+    });
+    return activitiesArrayWithPushToStartToken;
+ }
 
 /**
  * Returns the version of the Messaging extension for the currently selected client, if available.
@@ -303,5 +346,6 @@ export {
   useClientIOSVersion,
   useClientAndroidVersion,
   useClientLiveActivitiesSupport,
-  useClientDeviceType
+  useClientDeviceType,
+  useActivitiesWithPushToStartTokens
 };

--- a/packages/ui-plugins/live-activities/src/hooks/usePushCredentialsData.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/usePushCredentialsData.ts
@@ -86,6 +86,11 @@ async function getPushCredentials({
     },
     body
   });
+  
+  if (!response.ok) {
+    throw new Error(`Push credentials fetch failed: ${response.status}`);
+  }
+
   const json = await response.json();
   // Return the relevant data
   return json.data?.getPushCredentials || null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Push to start token per live activity

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
