### PR TITLE
La broadcast support refactor

### DIFF
--- a/packages/ui-plugins/live-activities/src/api/__tests__/liveActivityApi.test.ts
+++ b/packages/ui-plugins/live-activities/src/api/__tests__/liveActivityApi.test.ts
@@ -7,7 +7,9 @@ import {
   buildCompleteApsPayload,
   generateUpdateTemplate,
   generateLiveActivityPayload,
-  getCurrentTimestamp
+  getCurrentTimestamp,
+  ACTIVITY_TYPE,
+  EVENT_TYPE
 } from '../liveActivityApi';
 
 describe('LiveActivityApi - Broadcast Support', () => {
@@ -19,13 +21,13 @@ describe('LiveActivityApi - Broadcast Support', () => {
     it('should build payload without broadcast fields for unitary activities', () => {
       const result = buildCompleteApsPayload({
         userPayload: { 'content-state': { value: 10 } },
-        eventType: 'start',
+        eventType: EVENT_TYPE.START,
         attributesType: 'TestActivity'
       });
 
       expect(result).toMatchObject({
         'content-available': 1,
-        event: 'start',
+        event: EVENT_TYPE.START,
         'attributes-type': 'TestActivity',
         'content-state': { value: 10 }
       });
@@ -35,7 +37,7 @@ describe('LiveActivityApi - Broadcast Support', () => {
     it('should add broadcast fields when broadcastChannelId is provided', () => {
       const result = buildCompleteApsPayload({
         userPayload: { 'content-state': { value: 20 } },
-        eventType: 'start',
+        eventType: EVENT_TYPE.START,
         attributesType: 'BroadcastActivity',
         broadcastChannelId: 'channel-123'
       });
@@ -44,7 +46,7 @@ describe('LiveActivityApi - Broadcast Support', () => {
       expect(result.attributes.liveActivityData).toMatchObject({
         channelID: 'channel-123',
         origin: 'remote',
-        type: 'broadcast'
+        type: ACTIVITY_TYPE.BROADCAST
       });
     });
 
@@ -59,7 +61,7 @@ describe('LiveActivityApi - Broadcast Support', () => {
             }
           }
         },
-        eventType: 'update',
+        eventType: EVENT_TYPE.UPDATE,
         attributesType: 'BroadcastActivity',
         broadcastChannelId: 'channel-456'
       });
@@ -67,7 +69,7 @@ describe('LiveActivityApi - Broadcast Support', () => {
       expect(result.attributes.liveActivityData).toMatchObject({
         channelID: 'channel-456',
         origin: 'remote',
-        type: 'broadcast',
+        type: ACTIVITY_TYPE.BROADCAST,
         customField: 'customValue',
         userMetadata: { key: 'value' }
       });
@@ -76,21 +78,21 @@ describe('LiveActivityApi - Broadcast Support', () => {
     it('should handle update and end event types for broadcast', () => {
       const updateResult = buildCompleteApsPayload({
         userPayload: {},
-        eventType: 'update',
+        eventType: EVENT_TYPE.UPDATE,
         attributesType: 'Activity',
         broadcastChannelId: 'channel-789'
       });
 
       const endResult = buildCompleteApsPayload({
         userPayload: {},
-        eventType: 'end',
+        eventType: EVENT_TYPE.END,
         attributesType: 'Activity',
         broadcastChannelId: 'channel-789'
       });
 
-      expect(updateResult.event).toBe('update');
+      expect(updateResult.event).toBe(EVENT_TYPE.UPDATE);
       expect(updateResult['input-push-channel']).toBe('channel-789');
-      expect(endResult.event).toBe('end');
+      expect(endResult.event).toBe(EVENT_TYPE.END);
       expect(endResult['input-push-channel']).toBe('channel-789');
     });
   });
@@ -160,7 +162,7 @@ describe('LiveActivityApi - Broadcast Support', () => {
         apsContent: {
           'content-state': { value: 50 },
           'attributes-type': 'BroadcastTest',
-          event: 'start'
+          event: EVENT_TYPE.START
         },
         imsOrg: 'org-123',
         sandboxName: 'prod',
@@ -170,14 +172,14 @@ describe('LiveActivityApi - Broadcast Support', () => {
         token: 'push-token-123',
         ecid: 'ecid-123',
         environment: 'prod',
-        type: 'broadcast' as const,
+        type: ACTIVITY_TYPE.BROADCAST,
         broadcastChannelId: 'channel-test'
       };
 
       const result = generateLiveActivityPayload(params);
 
       const liveActivity = result.messages[0].value.notification.liveActivity;
-      expect(liveActivity.type).toBe('broadcast');
+      expect(liveActivity.type).toBe(ACTIVITY_TYPE.BROADCAST);
       expect(liveActivity.channelID).toBe('channel-test');
     });
 
@@ -186,7 +188,7 @@ describe('LiveActivityApi - Broadcast Support', () => {
         apsContent: {
           'content-state': { value: 60 },
           'attributes-type': 'UnitaryTest',
-          event: 'start'
+          event: EVENT_TYPE.START
         },
         imsOrg: 'org-456',
         sandboxName: 'prod',
@@ -196,13 +198,13 @@ describe('LiveActivityApi - Broadcast Support', () => {
         token: 'push-token-456',
         ecid: 'ecid-456',
         environment: 'prod',
-        type: 'unitary' as const
+        type: ACTIVITY_TYPE.UNITARY
       };
 
       const result = generateLiveActivityPayload(params);
 
       const liveActivity = result.messages[0].value.notification.liveActivity;
-      expect(liveActivity.type).toBe('unitary');
+      expect(liveActivity.type).toBe(ACTIVITY_TYPE.UNITARY);
       expect(liveActivity.channelID).toBeUndefined();
     });
   });

--- a/packages/ui-plugins/live-activities/src/api/__tests__/liveActivityApi.test.ts
+++ b/packages/ui-plugins/live-activities/src/api/__tests__/liveActivityApi.test.ts
@@ -7,10 +7,9 @@ import {
   buildCompleteApsPayload,
   generateUpdateTemplate,
   generateLiveActivityPayload,
-  getCurrentTimestamp,
-  ACTIVITY_TYPE,
-  EVENT_TYPE
+  getCurrentTimestamp
 } from '../liveActivityApi';
+import { ACTIVITY_TYPE, EVENT_TYPE } from '../../constants/liveActivitiesConfig';
 
 describe('LiveActivityApi - Broadcast Support', () => {
   beforeEach(() => {
@@ -103,7 +102,7 @@ describe('LiveActivityApi - Broadcast Support', () => {
         id: 'unitary-123',
         name: 'TestActivity',
         currentContentState: { value: 100 }
-      };
+      } as any;
 
       const result = generateUpdateTemplate(activity);
 
@@ -112,39 +111,38 @@ describe('LiveActivityApi - Broadcast Support', () => {
       expect(result.attributes.liveActivityData.channelID).toBeUndefined();
     });
 
-    it('should include channelID for broadcast activities', () => {
+    it('should not include channelID for broadcast activities in template', () => {
       const activity = {
         broadcastChannelId: 'channel-abc',
         name: 'BroadcastActivity',
         currentContentState: { value: 200 }
-      };
+      } as any;
 
       const result = generateUpdateTemplate(activity);
 
       expect(result['content-state']).toEqual({ value: 200 });
-      expect(result.attributes.liveActivityData.channelID).toBe('channel-abc');
+      expect(result.attributes.liveActivityData.channelID).toBeUndefined();
       expect(result.attributes.liveActivityData.liveActivityID).toBeUndefined();
     });
 
-    it('should include both IDs if both exist', () => {
+    it('should only include liveActivityID even if both IDs exist', () => {
       const activity = {
         id: 'activity-123',
         broadcastChannelId: 'channel-xyz',
         name: 'MixedActivity',
         currentContentState: {}
-      };
+      } as any;
 
       const result = generateUpdateTemplate(activity);
 
       expect(result.attributes.liveActivityData.liveActivityID).toBe('activity-123');
-      expect(result.attributes.liveActivityData.channelID).toBe('channel-xyz');
     });
 
     it('should handle missing IDs gracefully', () => {
       const activity = {
         name: 'ActivityWithNoIds',
         currentContentState: { value: 300 }
-      };
+      } as any;
 
       const result = generateUpdateTemplate(activity);
 

--- a/packages/ui-plugins/live-activities/src/api/__tests__/liveActivityApi.test.ts
+++ b/packages/ui-plugins/live-activities/src/api/__tests__/liveActivityApi.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for Live Activity API functions with broadcast support
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  buildCompleteApsPayload,
+  generateUpdateTemplate,
+  generateLiveActivityPayload,
+  getCurrentTimestamp
+} from '../liveActivityApi';
+
+describe('LiveActivityApi - Broadcast Support', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('buildCompleteApsPayload', () => {
+    it('should build payload without broadcast fields for unitary activities', () => {
+      const result = buildCompleteApsPayload({
+        userPayload: { 'content-state': { value: 10 } },
+        eventType: 'start',
+        attributesType: 'TestActivity'
+      });
+
+      expect(result).toMatchObject({
+        'content-available': 1,
+        event: 'start',
+        'attributes-type': 'TestActivity',
+        'content-state': { value: 10 }
+      });
+      expect(result['input-push-channel']).toBeUndefined();
+    });
+
+    it('should add broadcast fields when broadcastChannelId is provided', () => {
+      const result = buildCompleteApsPayload({
+        userPayload: { 'content-state': { value: 20 } },
+        eventType: 'start',
+        attributesType: 'BroadcastActivity',
+        broadcastChannelId: 'channel-123'
+      });
+
+      expect(result['input-push-channel']).toBe('channel-123');
+      expect(result.attributes.liveActivityData).toMatchObject({
+        channelID: 'channel-123',
+        origin: 'remote',
+        type: 'broadcast'
+      });
+    });
+
+    it('should preserve user custom fields in liveActivityData', () => {
+      const result = buildCompleteApsPayload({
+        userPayload: {
+          'content-state': { value: 30 },
+          attributes: {
+            liveActivityData: {
+              customField: 'customValue',
+              userMetadata: { key: 'value' }
+            }
+          }
+        },
+        eventType: 'update',
+        attributesType: 'BroadcastActivity',
+        broadcastChannelId: 'channel-456'
+      });
+
+      expect(result.attributes.liveActivityData).toMatchObject({
+        channelID: 'channel-456',
+        origin: 'remote',
+        type: 'broadcast',
+        customField: 'customValue',
+        userMetadata: { key: 'value' }
+      });
+    });
+
+    it('should handle update and end event types for broadcast', () => {
+      const updateResult = buildCompleteApsPayload({
+        userPayload: {},
+        eventType: 'update',
+        attributesType: 'Activity',
+        broadcastChannelId: 'channel-789'
+      });
+
+      const endResult = buildCompleteApsPayload({
+        userPayload: {},
+        eventType: 'end',
+        attributesType: 'Activity',
+        broadcastChannelId: 'channel-789'
+      });
+
+      expect(updateResult.event).toBe('update');
+      expect(updateResult['input-push-channel']).toBe('channel-789');
+      expect(endResult.event).toBe('end');
+      expect(endResult['input-push-channel']).toBe('channel-789');
+    });
+  });
+
+  describe('generateUpdateTemplate', () => {
+    it('should include liveActivityID for unitary activities', () => {
+      const activity = {
+        id: 'unitary-123',
+        name: 'TestActivity',
+        currentContentState: { value: 100 }
+      };
+
+      const result = generateUpdateTemplate(activity);
+
+      expect(result['content-state']).toEqual({ value: 100 });
+      expect(result.attributes.liveActivityData.liveActivityID).toBe('unitary-123');
+      expect(result.attributes.liveActivityData.channelID).toBeUndefined();
+    });
+
+    it('should include channelID for broadcast activities', () => {
+      const activity = {
+        broadcastChannelId: 'channel-abc',
+        name: 'BroadcastActivity',
+        currentContentState: { value: 200 }
+      };
+
+      const result = generateUpdateTemplate(activity);
+
+      expect(result['content-state']).toEqual({ value: 200 });
+      expect(result.attributes.liveActivityData.channelID).toBe('channel-abc');
+      expect(result.attributes.liveActivityData.liveActivityID).toBeUndefined();
+    });
+
+    it('should include both IDs if both exist', () => {
+      const activity = {
+        id: 'activity-123',
+        broadcastChannelId: 'channel-xyz',
+        name: 'MixedActivity',
+        currentContentState: {}
+      };
+
+      const result = generateUpdateTemplate(activity);
+
+      expect(result.attributes.liveActivityData.liveActivityID).toBe('activity-123');
+      expect(result.attributes.liveActivityData.channelID).toBe('channel-xyz');
+    });
+
+    it('should handle missing IDs gracefully', () => {
+      const activity = {
+        name: 'ActivityWithNoIds',
+        currentContentState: { value: 300 }
+      };
+
+      const result = generateUpdateTemplate(activity);
+
+      expect(result['content-state']).toEqual({ value: 300 });
+      expect(result.attributes.liveActivityData).toBeDefined();
+      // Should have neither ID
+      expect(result.attributes.liveActivityData.liveActivityID).toBeUndefined();
+      expect(result.attributes.liveActivityData.channelID).toBeUndefined();
+    });
+  });
+
+  describe('generateLiveActivityPayload', () => {
+    it('should generate payload with type and channelID for broadcast', () => {
+      const params = {
+        apsContent: {
+          'content-state': { value: 50 },
+          'attributes-type': 'BroadcastTest',
+          event: 'start'
+        },
+        imsOrg: 'org-123',
+        sandboxName: 'prod',
+        sessionId: 'session-123',
+        appId: 'com.test.app',
+        platform: 'ios',
+        token: 'push-token-123',
+        ecid: 'ecid-123',
+        environment: 'prod',
+        type: 'broadcast' as const,
+        broadcastChannelId: 'channel-test'
+      };
+
+      const result = generateLiveActivityPayload(params);
+
+      const liveActivity = result.messages[0].value.notification.liveActivity;
+      expect(liveActivity.type).toBe('broadcast');
+      expect(liveActivity.channelID).toBe('channel-test');
+    });
+
+    it('should generate payload without channelID for unitary', () => {
+      const params = {
+        apsContent: {
+          'content-state': { value: 60 },
+          'attributes-type': 'UnitaryTest',
+          event: 'start'
+        },
+        imsOrg: 'org-456',
+        sandboxName: 'prod',
+        sessionId: 'session-456',
+        appId: 'com.test.app',
+        platform: 'ios',
+        token: 'push-token-456',
+        ecid: 'ecid-456',
+        environment: 'prod',
+        type: 'unitary' as const
+      };
+
+      const result = generateLiveActivityPayload(params);
+
+      const liveActivity = result.messages[0].value.notification.liveActivity;
+      expect(liveActivity.type).toBe('unitary');
+      expect(liveActivity.channelID).toBeUndefined();
+    });
+  });
+
+  describe('getCurrentTimestamp', () => {
+    it('should return a valid unix timestamp', () => {
+      const timestamp = getCurrentTimestamp();
+      
+      expect(typeof timestamp).toBe('number');
+      expect(timestamp).toBeGreaterThan(1600000000); // After Sep 2020
+      expect(timestamp).toBeLessThan(2000000000); // Before May 2033
+    });
+  });
+});
+

--- a/packages/ui-plugins/live-activities/src/api/liveActivityApi.ts
+++ b/packages/ui-plugins/live-activities/src/api/liveActivityApi.ts
@@ -11,6 +11,24 @@ import { v4 as uuidv4 } from 'uuid';
 // CONSTANTS
 // ============================================================================
 
+// Live Activity Types
+export const ACTIVITY_TYPE = {
+  UNITARY: 'unitary',
+  BROADCAST: 'broadcast'
+} as const;
+
+export type ActivityType = typeof ACTIVITY_TYPE[keyof typeof ACTIVITY_TYPE];
+
+// Live Activity Event Types
+export const EVENT_TYPE = {
+  START: 'start',
+  UPDATE: 'update',
+  END: 'end',
+  REMOTE_START: 'remotestart'
+} as const;
+
+export type EventType = typeof EVENT_TYPE[keyof typeof EVENT_TYPE];
+
 export const API_ENDPOINTS = {
   local: 'https://local.griffon.adobe.com',
   dev: 'https://plugin-support-dev.griffon.adobe.com',
@@ -60,7 +78,7 @@ export interface LiveActivityPayloadParams {
   sessionId: string;
   sandboxName: string;
   environment: string;
-  type?: 'unitary' | 'broadcast';
+  type?: ActivityType;
   broadcastChannelId?: string;
 }
 
@@ -133,7 +151,7 @@ export function generateUpdateTemplate(activity: any): any {
  */
 export function buildCompleteApsPayload(params: {
   userPayload: any;
-  eventType: 'start' | 'update' | 'end';
+  eventType: typeof EVENT_TYPE.START | typeof EVENT_TYPE.UPDATE | typeof EVENT_TYPE.END;
   attributesType: string;
   broadcastChannelId?: string;
 }): any {
@@ -166,7 +184,7 @@ export function buildCompleteApsPayload(params: {
       ...basePayload.attributes.liveActivityData,  // Preserve user's custom fields
       channelID: params.broadcastChannelId,         // Our required field (override if exists)
       origin: "remote",                             // Our required field
-      type: "broadcast"                             // Our required field
+      type: ACTIVITY_TYPE.BROADCAST                 // Our required field
     };
   }
 
@@ -274,17 +292,17 @@ export function generateLiveActivityPayload(params: LiveActivityPayloadParams) {
   const normalizedAps = normalizeApsPayload(params.apsContent);
 
   // Determine event type - if 'start', map to 'remotestart'
-  const eventType = normalizedAps.event === 'start' ? 'remotestart' : normalizedAps.event;
+  const eventType = normalizedAps.event === EVENT_TYPE.START ? EVENT_TYPE.REMOTE_START : normalizedAps.event;
 
   // Build liveActivity object based on type
   const liveActivityPayload: any = {
-    type: params.type || 'unitary',
+    type: params.type || ACTIVITY_TYPE.UNITARY,
     event: eventType,
     liveActivityID: normalizedAps.attributes?.liveActivityData?.liveActivityID
   };
   
   // Add channelID for broadcast activities
-  if (params.type === 'broadcast' && params.broadcastChannelId) {
+  if (params.type === ACTIVITY_TYPE.BROADCAST && params.broadcastChannelId) {
     liveActivityPayload.channelID = params.broadcastChannelId;
   }
 

--- a/packages/ui-plugins/live-activities/src/api/liveActivityApi.ts
+++ b/packages/ui-plugins/live-activities/src/api/liveActivityApi.ts
@@ -6,28 +6,13 @@
 
 import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
+import { ACTIVITY_TYPE, EVENT_TYPE } from '../constants/liveActivitiesConfig';
+import type { ActivityType } from '../constants/liveActivitiesConfig';
+import { LiveActivity } from '../hooks/useActivities';
 
 // ============================================================================
 // CONSTANTS
 // ============================================================================
-
-// Live Activity Types
-export const ACTIVITY_TYPE = {
-  UNITARY: 'unitary',
-  BROADCAST: 'broadcast'
-} as const;
-
-export type ActivityType = typeof ACTIVITY_TYPE[keyof typeof ACTIVITY_TYPE];
-
-// Live Activity Event Types
-export const EVENT_TYPE = {
-  START: 'start',
-  UPDATE: 'update',
-  END: 'end',
-  REMOTE_START: 'remotestart'
-} as const;
-
-export type EventType = typeof EVENT_TYPE[keyof typeof EVENT_TYPE];
 
 export const API_ENDPOINTS = {
   local: 'https://local.griffon.adobe.com',
@@ -72,7 +57,7 @@ export interface LiveActivityPayloadParams {
   apsContent: any;
   appId: string;
   platform: string;
-  token: string; // This will be either pushToStartToken or updateToken
+  token?: string; // This will be either pushToStartToken or updateToken in unitary activities, empty string/undefined in broadcast activities
   ecid: string;
   imsOrg: string;
   sessionId: string;
@@ -122,18 +107,14 @@ export function generateLaunchTemplate(): any {
  * Generates minimal APS template for updating a Live Activity
  * Pre-fills known data from the activity, user only updates dynamic fields
  */
-export function generateUpdateTemplate(activity: any): any {
+export function generateUpdateTemplate(activity: LiveActivity): any {
   // Build liveActivityData object with only existing fields
   const liveActivityData: any = {};
+  console.log('activity', activity);
   
   // Add liveActivityID only if it exists
   if (activity.id) {
     liveActivityData.liveActivityID = activity.id;
-  }
-  
-  // Add channelID only if it exists (for broadcast activities)
-  if (activity.broadcastChannelId) {
-    liveActivityData.channelID = activity.broadcastChannelId;
   }
   
   const template: any = {
@@ -169,22 +150,21 @@ export function buildCompleteApsPayload(params: {
 
   // Add broadcast channel ID to APS payload if provided
   if (params.broadcastChannelId) {
+    // Add broadcast channel ID to APS payload
     basePayload["input-push-channel"] = params.broadcastChannelId;
     
-    // Safely ensure nested structure exists
-    if (!basePayload.attributes) {
-      basePayload.attributes = {};
-    }
-    if (!basePayload.attributes.liveActivityData) {
-      basePayload.attributes.liveActivityData = {};
-    }
+    // Preserve user's custom liveActivityData fields
+    const userLiveActivityData = basePayload.attributes?.liveActivityData || {};
     
-    // Merge broadcast-specific fields while preserving user's custom fields
-    basePayload.attributes.liveActivityData = {
-      ...basePayload.attributes.liveActivityData,  // Preserve user's custom fields
-      channelID: params.broadcastChannelId,         // Our required field (override if exists)
-      origin: "remote",                             // Our required field
-      type: ACTIVITY_TYPE.BROADCAST                 // Our required field
+    // Merge with broadcast-required fields (broadcast fields take precedence)
+    basePayload.attributes = {
+      ...basePayload.attributes,
+      liveActivityData: {
+        ...userLiveActivityData,
+        channelID: params.broadcastChannelId,
+        origin: "remote",
+        type: ACTIVITY_TYPE.BROADCAST
+      }
     };
   }
 

--- a/packages/ui-plugins/live-activities/src/api/liveActivityApi.ts
+++ b/packages/ui-plugins/live-activities/src/api/liveActivityApi.ts
@@ -105,7 +105,7 @@ export function generateLaunchTemplate(): any {
  * Pre-fills known data from the activity, user only updates dynamic fields
  */
 export function generateUpdateTemplate(activity: any): any {
-  return {
+  const template: any = {
     "content-state": activity.currentContentState || activity.examplePayload?.['content-state'] || {},
     "attributes": {
       "liveActivityData": {
@@ -113,6 +113,15 @@ export function generateUpdateTemplate(activity: any): any {
       }
     }
   };
+  
+  // Add broadcast-specific fields
+  if (activity.type === 'broadcast' && activity.broadcastChannelId) {
+    template.attributes.liveActivityData.channelID = activity.broadcastChannelId;
+    template.attributes.liveActivityData.type = 'broadcast';
+    template.attributes.liveActivityData.origin = 'remote';
+  }
+  
+  return template;
 }
 
 /**
@@ -139,8 +148,18 @@ export function buildCompleteApsPayload(params: {
   // Add broadcast channel ID to APS payload if provided
   if (params.broadcastChannelId) {
     basePayload["input-push-channel"] = params.broadcastChannelId;
+    
+    // Safely ensure nested structure exists
+    if (!basePayload.attributes) {
+      basePayload.attributes = {};
+    }
+    if (!basePayload.attributes.liveActivityData) {
+      basePayload.attributes.liveActivityData = {};
+    }
+    
+    // Set broadcast-specific fields
     basePayload.attributes.liveActivityData.channelID = params.broadcastChannelId;
-    basePayload.attributes.liveActivityData.origin =  "remote"; 
+    basePayload.attributes.liveActivityData.origin = "remote";
     basePayload.attributes.liveActivityData.type = "broadcast";
   }
 
@@ -250,6 +269,18 @@ export function generateLiveActivityPayload(params: LiveActivityPayloadParams) {
   // Determine event type - if 'start', map to 'remotestart'
   const eventType = normalizedAps.event === 'start' ? 'remotestart' : normalizedAps.event;
 
+  // Build liveActivity object based on type
+  const liveActivityPayload: any = {
+    type: params.type || 'unitary',
+    event: eventType,
+    liveActivityID: normalizedAps.attributes?.liveActivityData?.liveActivityID
+  };
+  
+  // Add channelID for broadcast activities
+  if (params.type === 'broadcast' && params.broadcastChannelId) {
+    liveActivityPayload.channelID = params.broadcastChannelId;
+  }
+
   return {
     messages: [
       {
@@ -261,11 +292,7 @@ export function generateLiveActivityPayload(params: LiveActivityPayloadParams) {
             },
             groupID: groupId,
             sandboxName: params.sandboxName,
-            liveActivity: {
-              type: params.type || 'unitary',
-              event: eventType,
-              liveActivityID: normalizedAps.attributes?.liveActivityData?.liveActivityID
-            },
+            liveActivity: liveActivityPayload,
             pushTokenDetail: {
               appID: params.appId,
               platform: params.platform,

--- a/packages/ui-plugins/live-activities/src/api/liveActivityApi.ts
+++ b/packages/ui-plugins/live-activities/src/api/liveActivityApi.ts
@@ -105,21 +105,25 @@ export function generateLaunchTemplate(): any {
  * Pre-fills known data from the activity, user only updates dynamic fields
  */
 export function generateUpdateTemplate(activity: any): any {
+  // Build liveActivityData object with only existing fields
+  const liveActivityData: any = {};
+  
+  // Add liveActivityID only if it exists
+  if (activity.id) {
+    liveActivityData.liveActivityID = activity.id;
+  }
+  
+  // Add channelID only if it exists (for broadcast activities)
+  if (activity.broadcastChannelId) {
+    liveActivityData.channelID = activity.broadcastChannelId;
+  }
+  
   const template: any = {
     "content-state": activity.currentContentState || activity.examplePayload?.['content-state'] || {},
     "attributes": {
-      "liveActivityData": {
-        "liveActivityID": activity.id || ""
-      }
+      "liveActivityData": liveActivityData
     }
   };
-  
-  // Add broadcast-specific fields
-  if (activity.type === 'broadcast' && activity.broadcastChannelId) {
-    template.attributes.liveActivityData.channelID = activity.broadcastChannelId;
-    template.attributes.liveActivityData.type = 'broadcast';
-    template.attributes.liveActivityData.origin = 'remote';
-  }
   
   return template;
 }
@@ -157,10 +161,13 @@ export function buildCompleteApsPayload(params: {
       basePayload.attributes.liveActivityData = {};
     }
     
-    // Set broadcast-specific fields
-    basePayload.attributes.liveActivityData.channelID = params.broadcastChannelId;
-    basePayload.attributes.liveActivityData.origin = "remote";
-    basePayload.attributes.liveActivityData.type = "broadcast";
+    // Merge broadcast-specific fields while preserving user's custom fields
+    basePayload.attributes.liveActivityData = {
+      ...basePayload.attributes.liveActivityData,  // Preserve user's custom fields
+      channelID: params.broadcastChannelId,         // Our required field (override if exists)
+      origin: "remote",                             // Our required field
+      type: "broadcast"                             // Our required field
+    };
   }
 
   return basePayload;

--- a/packages/ui-plugins/live-activities/src/api/liveActivityApi.ts
+++ b/packages/ui-plugins/live-activities/src/api/liveActivityApi.ts
@@ -110,7 +110,6 @@ export function generateLaunchTemplate(): any {
 export function generateUpdateTemplate(activity: LiveActivity): any {
   // Build liveActivityData object with only existing fields
   const liveActivityData: any = {};
-  console.log('activity', activity);
   
   // Add liveActivityID only if it exists
   if (activity.id) {

--- a/packages/ui-plugins/live-activities/src/api/liveActivityApi.ts
+++ b/packages/ui-plugins/live-activities/src/api/liveActivityApi.ts
@@ -60,6 +60,8 @@ export interface LiveActivityPayloadParams {
   sessionId: string;
   sandboxName: string;
   environment: string;
+  type?: 'unitary' | 'broadcast';
+  broadcastChannelId?: string;
 }
 
 export interface ApiCallConfig {
@@ -120,8 +122,9 @@ export function buildCompleteApsPayload(params: {
   userPayload: any;
   eventType: 'start' | 'update' | 'end';
   attributesType: string;
+  broadcastChannelId?: string;
 }): any {
-  return {
+  const basePayload = {
     "content-available": 1,
     "timestamp": getCurrentTimestamp(),
     "event": params.eventType,
@@ -132,6 +135,16 @@ export function buildCompleteApsPayload(params: {
     },
     ...params.userPayload
   };
+
+  // Add broadcast channel ID to APS payload if provided
+  if (params.broadcastChannelId) {
+    basePayload["input-push-channel"] = params.broadcastChannelId;
+    basePayload.attributes.liveActivityData.channelID = params.broadcastChannelId;
+    basePayload.attributes.liveActivityData.origin =  "remote"; 
+    basePayload.attributes.liveActivityData.type = "broadcast";
+  }
+
+  return basePayload;
 }
 
 /**
@@ -249,7 +262,7 @@ export function generateLiveActivityPayload(params: LiveActivityPayloadParams) {
             groupID: groupId,
             sandboxName: params.sandboxName,
             liveActivity: {
-              type: 'unitary',
+              type: params.type || 'unitary',
               event: eventType,
               liveActivityID: normalizedAps.attributes?.liveActivityData?.liveActivityID
             },

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.css
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.css
@@ -39,3 +39,59 @@
   color: #9ca3af;
   font-weight: 400;
 }
+
+.activityCardBase {
+  border: 2px solid #d1d5db;
+  border-radius: 8px;
+  background-color: #ffffff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  transition: all 0.2s ease-in-out;
+  cursor: pointer;
+  min-height: 80px;
+  padding-top: 16px;
+  margin: 2px;
+  position: relative;
+}
+
+.activityCardSelected {
+  border-color: #3b82f6;
+  background-color: #dbeafe;
+  box-shadow: 0 0 0 1px #3b82f6, 0 4px 12px rgba(59, 130, 246, 0.15);
+}
+
+.typeBadge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 6px;
+  z-index: 1;
+}
+
+.typeBadgeBroadcast {
+  background-color: #f3e8ff;
+  border: 1px solid #e9d5ff;
+}
+
+.typeBadgeUnitary {
+  background-color: #dbeafe;
+  border: 1px solid #bfdbfe;
+}
+
+.typeBadgeTextBase {
+  font-size: 6px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+}
+
+.typeBadgeTextBroadcast {
+  color: #7c3aed;
+}
+
+.typeBadgeTextUnitary {
+  color: #2563eb;
+}

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.css
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.css
@@ -2,7 +2,7 @@
   font-weight: 600;
   font-size: 14px;
   line-height: 1.4;
-  color: #1f2937;
+  color: var(--spectrum-global-color-gray-800);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -13,7 +13,7 @@
 
 .typeLabel {
   font-size: 11px;
-  color: #9ca3af;
+  color: var(--spectrum-global-color-gray-500);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.025em;
@@ -21,7 +21,7 @@
 
 .typeValue {
   font-size: 12px;
-  color: #6b7280;
+  color: var(--spectrum-global-color-gray-600);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -30,20 +30,20 @@
 
 .eventCountText {
   font-size: 11px;
-  color: #9ca3af;
+  color: var(--spectrum-global-color-gray-500);
   font-weight: 500;
 }
 
 .timestampText {
   font-size: 11px;
-  color: #9ca3af;
+  color: var(--spectrum-global-color-gray-500);
   font-weight: 400;
 }
 
 .activityCardBase {
-  border: 2px solid #d1d5db;
+  border: 2px solid var(--spectrum-global-color-gray-200);
   border-radius: 8px;
-  background-color: #ffffff;
+  background-color: var(--spectrum-global-color-static-white);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   transition: all 0.2s ease-in-out;
   cursor: pointer;
@@ -54,9 +54,9 @@
 }
 
 .activityCardSelected {
-  border-color: #3b82f6;
-  background-color: #dbeafe;
-  box-shadow: 0 0 0 1px #3b82f6, 0 4px 12px rgba(59, 130, 246, 0.15);
+  border-color: var(--spectrum-global-color-blue-600);
+  background-color: var(--spectrum-global-color-blue-200);
+  box-shadow: 0 0 0 1px var(--spectrum-global-color-blue-600), 0 4px 12px rgba(59, 130, 246, 0.15);
 }
 
 .typeBadge {
@@ -71,27 +71,27 @@
 }
 
 .typeBadgeBroadcast {
-  background-color: #f3e8ff;
-  border: 1px solid #e9d5ff;
+  background-color: var(--spectrum-global-color-purple-100);
+  border: 1px solid var(--spectrum-global-color-purple-400);
 }
 
 .typeBadgeUnitary {
-  background-color: #dbeafe;
-  border: 1px solid #bfdbfe;
+  background-color: var(--spectrum-global-color-blue-100);
+  border: 1px solid var(--spectrum-global-color-blue-400);
 }
 
 .typeBadgeTextBase {
   font-size: 6px;
-  font-weight: 600;
+  font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.3px;
   white-space: nowrap;
 }
 
 .typeBadgeTextBroadcast {
-  color: #7c3aed;
+  color: var(--spectrum-global-color-purple-400);
 }
 
 .typeBadgeTextUnitary {
-  color: #2563eb;
+  color: var(--spectrum-global-color-blue-400);
 }

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
@@ -104,29 +104,45 @@ function ActivityCard({ activity, isSelected, onSelect }: ActivityCardProps) {
         height="100%"
         justifyContent="space-between"        
       >
-        {/* Header with status and Live Activity ID (primary identifier) */}
+        {/* Header with status and Live Activity ID/Channel (primary identifier) */}
         <Flex alignItems="center" gap="size-100">
           <StatusLight variant={getStatusVariant(activity.status)} />
-            <Text 
-              UNSAFE_className={classNames('activityIdText')}
-            >
-              {activity.broadcastChannelId? activity.broadcastChannelId : activity.id}
-            </Text>
+          <Flex direction="column" gap="size-25">
+            {activity.type === 'broadcast' && activity.broadcastChannelId ? (
+              <>
+                <Text UNSAFE_className={classNames('activityIdText')}>
+                  Channel: {activity.broadcastChannelId}
+                </Text>
+                <Text 
+                  UNSAFE_className={classNames('typeValue')}
+                  UNSAFE_style={{ fontSize: '11px', color: '#6b7280' }}
+                >
+                  Activity: {activity.name}
+                </Text>
+              </>
+            ) : (
+              <Text UNSAFE_className={classNames('activityIdText')}>
+                {activity.id}
+              </Text>
+            )}
+          </Flex>
         </Flex>
         
-        {/* Attribute Type (secondary info) */}
-        <Flex alignItems="center" gap="size-50">
-          <Text 
-            UNSAFE_className={classNames('typeLabel')}
-          >
-            Type:
-          </Text>
-          <Text 
-            UNSAFE_className={classNames('typeValue')}
-          >
-            {activity.name}
-          </Text>
-        </Flex>
+        {/* Attribute Type (secondary info) - Only show for unitary activities */}
+        {activity.type !== 'broadcast' && (
+          <Flex alignItems="center" gap="size-50">
+            <Text 
+              UNSAFE_className={classNames('typeLabel')}
+            >
+              Type:
+            </Text>
+            <Text 
+              UNSAFE_className={classNames('typeValue')}
+            >
+              {activity.name}
+            </Text>
+          </Flex>
+        )}
         
         {/* Footer with event count and timing */}
         <Flex alignItems="center" justifyContent="space-between" gap="size-100">

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
@@ -68,33 +68,22 @@ function ActivityCard({ activity, isSelected, onSelect }: ActivityCardProps) {
         position: 'relative'
       }}
     >
-      {/* Type Pill - Absolutely Positioned Top Right */}
+      {/* Type Badge - Absolutely Positioned Top Right */}
       <View
         borderRadius="regular"
-        UNSAFE_style={{
-          position: 'absolute',
-          top: '6px',
-          right: '6px',
-          backgroundColor: activity.type === 'broadcast' ? '#f3e8ff' : '#dbeafe',
-          border: `1px solid ${activity.type === 'broadcast' ? '#e9d5ff' : '#bfdbfe'}`,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          padding: '2px 6px',
-          zIndex: 1
-        }}
+        UNSAFE_className={classNames('typeBadge', {
+          'typeBadgeBroadcast': activity.type === 'broadcast',
+          'typeBadgeUnitary': activity.type !== 'broadcast'
+        })}
+        aria-label={`Activity type: ${activity.type === 'broadcast' ? formatMessage(activitiesMessages.typeBroadcast) : formatMessage(activitiesMessages.typeUnitary)}`}
       >
         <Text
-          UNSAFE_style={{
-            color: activity.type === 'broadcast' ? '#7c3aed' : '#2563eb',
-            fontSize: '6px',
-            fontWeight: 600,
-            textTransform: 'uppercase',
-            letterSpacing: '0.3px',
-            whiteSpace: 'nowrap'
-          }}
+          UNSAFE_className={classNames('typeBadgeTextBase', {
+            'typeBadgeTextBroadcast': activity.type === 'broadcast',
+            'typeBadgeTextUnitary': activity.type !== 'broadcast'
+          })}
         >
-          {activity.type === 'broadcast' ? 'Broadcast' : 'Unitary'}
+          {activity.type === 'broadcast' ? formatMessage(activitiesMessages.typeBroadcast) : formatMessage(activitiesMessages.typeUnitary)}
         </Text>
       </View>
 

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
@@ -9,6 +9,7 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
 import SpectrumCard from '../atoms/SpectrumCard';
+import { ACTIVITY_TYPE } from '../../api/liveActivityApi';
 import { LiveActivity, getActivityKey } from '../../hooks/useActivities';
 import { activitiesMessages } from '../../i18n';
 import './ActivityCard.css';

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
@@ -72,18 +72,18 @@ function ActivityCard({ activity, isSelected, onSelect }: ActivityCardProps) {
       <View
         borderRadius="regular"
         UNSAFE_className={classNames('typeBadge', {
-          'typeBadgeBroadcast': activity.type === 'broadcast',
-          'typeBadgeUnitary': activity.type !== 'broadcast'
+          'typeBadgeBroadcast': activity.type === ACTIVITY_TYPE.BROADCAST,
+          'typeBadgeUnitary': activity.type !== ACTIVITY_TYPE.BROADCAST
         })}
-        aria-label={`Activity type: ${activity.type === 'broadcast' ? formatMessage(activitiesMessages.typeBroadcast) : formatMessage(activitiesMessages.typeUnitary)}`}
+        aria-label={`Activity type: ${activity.type === ACTIVITY_TYPE.BROADCAST ? formatMessage(activitiesMessages.typeBroadcast) : formatMessage(activitiesMessages.typeUnitary)}`}
       >
         <Text
           UNSAFE_className={classNames('typeBadgeTextBase', {
-            'typeBadgeTextBroadcast': activity.type === 'broadcast',
-            'typeBadgeTextUnitary': activity.type !== 'broadcast'
+            'typeBadgeTextBroadcast': activity.type === ACTIVITY_TYPE.BROADCAST,
+            'typeBadgeTextUnitary': activity.type !== ACTIVITY_TYPE.BROADCAST
           })}
         >
-          {activity.type === 'broadcast' ? formatMessage(activitiesMessages.typeBroadcast) : formatMessage(activitiesMessages.typeUnitary)}
+          {activity.type === ACTIVITY_TYPE.BROADCAST ? formatMessage(activitiesMessages.typeBroadcast) : formatMessage(activitiesMessages.typeUnitary)}
         </Text>
       </View>
 

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
@@ -97,53 +97,26 @@ function ActivityCard({ activity, isSelected, onSelect }: ActivityCardProps) {
           {activity.type === 'broadcast' ? 'Broadcast' : 'Unitary'}
         </Text>
       </View>
-      
-      <Flex 
-        direction="column" 
-        gap="size-75" 
-        height="100%"
-        justifyContent="space-between"        
-      >
-        {/* Header with status and Live Activity ID/Channel (primary identifier) */}
-        <Flex alignItems="center" gap="size-100">
-          <StatusLight variant={getStatusVariant(activity.status)} />
-          <Flex direction="column" gap="size-25">
-            {activity.type === 'broadcast' && activity.broadcastChannelId ? (
-              <>
-                <Text UNSAFE_className={classNames('activityIdText')}>
-                  Channel: {activity.broadcastChannelId}
-                </Text>
-                <Text 
-                  UNSAFE_className={classNames('typeValue')}
-                  UNSAFE_style={{ fontSize: '11px', color: '#6b7280' }}
-                >
-                  Activity: {activity.name}
-                </Text>
-              </>
-            ) : (
+
+      <Flex direction="column" gap="size-75" height="100%" justifyContent="space-between">
+        {/* Header with status and Live Activity ID (primary identifier) */}
+        <Flex alignItems="center" gap="size-100" justifyContent="space-between">
+          <Flex wrap alignItems="center" gap="size-100" flex="1" minWidth="0">
+            <StatusLight variant={getStatusVariant(activity.status)} />
+            {activity.broadcastChannelId ? (
               <Text UNSAFE_className={classNames('activityIdText')}>
-                {activity.id}
+                {activity.broadcastChannelId}
               </Text>
+            ) : (
+              <Text UNSAFE_className={classNames('activityIdText')}>{activity.id}</Text>
             )}
           </Flex>
         </Flex>
-        
-        {/* Attribute Type (secondary info) - Only show for unitary activities */}
-        {activity.type !== 'broadcast' && (
-          <Flex alignItems="center" gap="size-50">
-            <Text 
-              UNSAFE_className={classNames('typeLabel')}
-            >
-              Type:
-            </Text>
-            <Text 
-              UNSAFE_className={classNames('typeValue')}
-            >
-              {activity.name}
-            </Text>
-          </Flex>
-        )}
-        
+        {/* Attribute Type (secondary info) */}
+        <Flex alignItems="center" gap="size-50">
+          <Text UNSAFE_className={classNames('typeLabel')}>Type:</Text>
+          <Text UNSAFE_className={classNames('typeValue')}>{activity.name}</Text>
+        </Flex>
         {/* Footer with event count and timing */}
         <Flex alignItems="center" justifyContent="space-between" gap="size-100">
           <Text 
@@ -151,7 +124,7 @@ function ActivityCard({ activity, isSelected, onSelect }: ActivityCardProps) {
           >
             {eventCount} {formatMessage(activitiesMessages.eventsCount)}
           </Text>
-          
+
           {lastActivityTime && (
             <Text 
               UNSAFE_className={classNames('timestampText')}

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
@@ -9,7 +9,7 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
 import SpectrumCard from '../atoms/SpectrumCard';
-import { ACTIVITY_TYPE } from '../../api/liveActivityApi';
+import { ACTIVITY_TYPE } from '../../constants/liveActivitiesConfig';
 import { LiveActivity, getActivityKey } from '../../hooks/useActivities';
 import { activitiesMessages } from '../../i18n';
 import './ActivityCard.css';
@@ -104,7 +104,7 @@ function ActivityCard({ activity, isSelected, onSelect }: ActivityCardProps) {
         </Flex>
         {/* Attribute Type (secondary info) */}
         <Flex alignItems="center" gap="size-50">
-          <Text UNSAFE_className={classNames('typeLabel')}>Type:</Text>
+          <Text UNSAFE_className={classNames('typeLabel')}>{formatMessage(activitiesMessages.type)}:</Text>
           <Text UNSAFE_className={classNames('typeValue')}>{activity.name}</Text>
         </Flex>
         {/* Footer with event count and timing */}

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, StatusLight } from '@adobe/react-spectrum';
+import { Flex, Text, StatusLight, View } from '@adobe/react-spectrum';
 
 import React from 'react';
 
@@ -9,7 +9,7 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
 import SpectrumCard from '../atoms/SpectrumCard';
-import { LiveActivity } from '../../hooks/useActivities';
+import { LiveActivity, getActivityKey } from '../../hooks/useActivities';
 import { activitiesMessages } from '../../i18n';
 import './ActivityCard.css';
 
@@ -18,7 +18,7 @@ dayjs.extend(relativeTime);
 interface ActivityCardProps {
   activity: LiveActivity;
   isSelected: boolean;
-  onSelect: (id: string) => void;
+  onSelect: (key: string) => void;
 }
 
 function ActivityCard({ activity, isSelected, onSelect }: ActivityCardProps) {
@@ -48,7 +48,7 @@ function ActivityCard({ activity, isSelected, onSelect }: ActivityCardProps) {
     <SpectrumCard
       isSelected={isSelected}
       onPress={() => {
-        onSelect(activity.id);
+        onSelect(getActivityKey(activity));
       }}
       marginBottom="size-100"
       padding="2px"
@@ -72,15 +72,49 @@ function ActivityCard({ activity, isSelected, onSelect }: ActivityCardProps) {
         height="100%"
         justifyContent="space-between"        
       >
-        {/* Header with status and Live Activity ID (primary identifier) */}
+        {/* Header with status, type badge, and Live Activity ID (primary identifier) */}
         <Flex alignItems="center" gap="size-100" justifyContent="space-between">
           <Flex wrap alignItems="center" gap="size-100" flex="1" minWidth="0">
-            <StatusLight  variant={getStatusVariant(activity.status)} />
-            <Text 
-              UNSAFE_className={classNames('activityIdText')}
+            <StatusLight variant={getStatusVariant(activity.status)} />
+            
+            {/* Type Badge */}
+            <View
+              paddingX="size-100"
+              paddingY="size-50"
+              borderRadius="small"
+              UNSAFE_style={{
+                backgroundColor: activity.type === 'broadcast' ? '#7c3aed' : '#2563eb',
+                display: 'inline-block'
+              }}
             >
-              {activity.id}
-            </Text>
+              <Text
+                UNSAFE_style={{
+                  color: 'white',
+                  fontSize: '10px',
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.5px'
+                }}
+              >
+                {activity.type === 'broadcast' ? '📡 Broadcast' : '🎮 Unitary'}
+              </Text>
+            </View>
+            
+            {/* Activity ID or Channel ID */}
+            {activity.id && (
+              <Text 
+                UNSAFE_className={classNames('activityIdText')}
+              >
+                {activity.id}
+              </Text>
+            )}
+            {activity.broadcastChannelId && (
+              <Text 
+                UNSAFE_className={classNames('broadcastChannelIdText')}
+              >
+                {activity.broadcastChannelId}
+              </Text>
+            )}
           </Flex>  
         </Flex>
         

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityCard.tsx
@@ -63,59 +63,55 @@ function ActivityCard({ activity, isSelected, onSelect }: ActivityCardProps) {
         transition: 'all 0.2s ease-in-out',
         cursor: 'pointer',
         minHeight: '80px',
-        margin: '2px'
+        paddingTop: '16px',
+        margin: '2px',
+        position: 'relative'
       }}
     >
+      {/* Type Pill - Absolutely Positioned Top Right */}
+      <View
+        borderRadius="regular"
+        UNSAFE_style={{
+          position: 'absolute',
+          top: '6px',
+          right: '6px',
+          backgroundColor: activity.type === 'broadcast' ? '#f3e8ff' : '#dbeafe',
+          border: `1px solid ${activity.type === 'broadcast' ? '#e9d5ff' : '#bfdbfe'}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '2px 6px',
+          zIndex: 1
+        }}
+      >
+        <Text
+          UNSAFE_style={{
+            color: activity.type === 'broadcast' ? '#7c3aed' : '#2563eb',
+            fontSize: '6px',
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.3px',
+            whiteSpace: 'nowrap'
+          }}
+        >
+          {activity.type === 'broadcast' ? 'Broadcast' : 'Unitary'}
+        </Text>
+      </View>
+      
       <Flex 
         direction="column" 
         gap="size-75" 
         height="100%"
         justifyContent="space-between"        
       >
-        {/* Header with status, type badge, and Live Activity ID (primary identifier) */}
-        <Flex alignItems="center" gap="size-100" justifyContent="space-between">
-          <Flex wrap alignItems="center" gap="size-100" flex="1" minWidth="0">
-            <StatusLight variant={getStatusVariant(activity.status)} />
-            
-            {/* Type Badge */}
-            <View
-              paddingX="size-100"
-              paddingY="size-50"
-              borderRadius="small"
-              UNSAFE_style={{
-                backgroundColor: activity.type === 'broadcast' ? '#7c3aed' : '#2563eb',
-                display: 'inline-block'
-              }}
+        {/* Header with status and Live Activity ID (primary identifier) */}
+        <Flex alignItems="center" gap="size-100">
+          <StatusLight variant={getStatusVariant(activity.status)} />
+            <Text 
+              UNSAFE_className={classNames('activityIdText')}
             >
-              <Text
-                UNSAFE_style={{
-                  color: 'white',
-                  fontSize: '10px',
-                  fontWeight: 600,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.5px'
-                }}
-              >
-                {activity.type === 'broadcast' ? '📡 Broadcast' : '🎮 Unitary'}
-              </Text>
-            </View>
-            
-            {/* Activity ID or Channel ID */}
-            {activity.id && (
-              <Text 
-                UNSAFE_className={classNames('activityIdText')}
-              >
-                {activity.id}
-              </Text>
-            )}
-            {activity.broadcastChannelId && (
-              <Text 
-                UNSAFE_className={classNames('broadcastChannelIdText')}
-              >
-                {activity.broadcastChannelId}
-              </Text>
-            )}
-          </Flex>  
+              {activity.broadcastChannelId? activity.broadcastChannelId : activity.id}
+            </Text>
         </Flex>
         
         {/* Attribute Type (secondary info) */}

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
@@ -25,13 +25,15 @@ interface ActivityListProps {
   selectedActivityId?: string;
   onActivitySelect: (key: string) => void;
   isLoading?: boolean;
+  actionButton?: React.ReactNode;
 }
 
 function ActivityList({
   activities,
   selectedActivityId,
   onActivitySelect,
-  isLoading = false
+  isLoading = false,
+  actionButton
 }: ActivityListProps) {
   const { formatMessage } = useIntl();
   const [searchQuery, setSearchQuery] = useState('');
@@ -103,13 +105,20 @@ function ActivityList({
   }
 
   return (
-    <View padding="size-200" height="100%">
+    <View padding="size-200" paddingTop="size-0" height="100%">
       <Flex direction="column" gap="size-200" height="100%">
         {/* Header */}
         <Flex direction="column" gap="size-100">
-          <Heading level={2} margin="size-0">
-            Live Activities ({activities.length})
-          </Heading>
+          <Flex direction="row" justifyContent="space-between" alignItems="center">
+            <Heading level={2} margin="size-0">
+              Live Activities ({activities.length})
+            </Heading>
+            {actionButton && (
+              <Flex alignItems="center" gap="size-100">
+                {actionButton}
+              </Flex>
+            )}
+          </Flex>
           <Text UNSAFE_className={classNames('subtitleText')}>
             Each activity is identified by its unique Live Activity ID
           </Text>

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
@@ -62,37 +62,6 @@ function ActivityList({
     });
   }, [activities, lowerSearchQuery, selectedFilter, selectedTypeFilter]);
 
-  // Count activities by status (total counts)
-  const statusCounts = useMemo(() => {
-    return {
-      all: activities.length,
-      active: activities.filter(a => a.status === 'active').length,
-      completed: activities.filter(a => a.status === 'completed').length
-    };
-  }, [activities]);
-
-  // Count activities by type (reflecting search and status filters, but not type filter)
-  const typeCounts = useMemo(() => {
-    const activitiesAfterSearchAndStatus = activities.filter(activity => {
-      const matchesSearch =
-        searchQuery === '' ||
-        activity.name.toLowerCase().includes(lowerSearchQuery) ||
-        activity.attributes?.toLowerCase().includes(lowerSearchQuery) ||
-        activity.id?.toLowerCase().includes(lowerSearchQuery) ||
-        activity.broadcastChannelId?.toLowerCase().includes(lowerSearchQuery);
-
-      const matchesStatusFilter = selectedFilter === 'all' || activity.status === selectedFilter;
-
-      return matchesSearch && matchesStatusFilter;
-    });
-
-    return {
-      all: activitiesAfterSearchAndStatus.length,
-      unitary: activitiesAfterSearchAndStatus.filter(a => a.type === 'unitary').length,
-      broadcast: activitiesAfterSearchAndStatus.filter(a => a.type === 'broadcast').length
-    };
-  }, [activities, lowerSearchQuery, searchQuery, selectedFilter]);
-
   if (isLoading) {
     return (
       <View padding="size-200">
@@ -141,10 +110,10 @@ function ActivityList({
               width="size-3000"
             >
               <Item key="all">
-                <Text>All</Text>
+                <Text>{formatMessage(activitiesMessages.allActivities)}</Text>
               </Item>
-              <Item key="unitary"><Text>Unitary</Text></Item>
-              <Item key="broadcast"><Text>Broadcast</Text></Item>
+              <Item key="unitary"><Text>{formatMessage(activitiesMessages.typeUnitary)}</Text></Item>
+              <Item key="broadcast"><Text>{formatMessage(activitiesMessages.typeBroadcast)}</Text></Item>
             </Picker>
 
             {/* Status Filter Dropdown */}

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
@@ -14,7 +14,7 @@ import React, { useState, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import classNames from 'classnames';
 
-import { LiveActivity } from '../../hooks/useActivities';
+import { LiveActivity, getActivityKey } from '../../hooks/useActivities';
 import { activitiesMessages } from '../../i18n';
 
 import ActivityCard from './ActivityCard';
@@ -23,7 +23,7 @@ import './ActivityList.css';
 interface ActivityListProps {
   activities: LiveActivity[];
   selectedActivityId?: string;
-  onActivitySelect: (id: string) => void;
+  onActivitySelect: (key: string) => void;
   isLoading?: boolean;
 }
 
@@ -36,6 +36,7 @@ function ActivityList({
   const { formatMessage } = useIntl();
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedFilter, setSelectedFilter] = useState<string>('all');
+  const [selectedTypeFilter, setSelectedTypeFilter] = useState<'all' | 'unitary' | 'broadcast'>('all');
 
   // Memoize lowercase search query to avoid repeated conversions
   const lowerSearchQuery = useMemo(() => searchQuery.toLowerCase(), [searchQuery]);
@@ -45,20 +46,24 @@ function ActivityList({
     return activities.filter(activity => {
       const matchesSearch = activity.name.toLowerCase().includes(lowerSearchQuery) ||
                            activity.attributes?.toLowerCase().includes(lowerSearchQuery) ||
-                           activity.id?.toLowerCase().includes(lowerSearchQuery)
+                           activity.id?.toLowerCase().includes(lowerSearchQuery) ||
                            activity.broadcastChannelId?.toLowerCase().includes(lowerSearchQuery);
                            
-      const matchesFilter = selectedFilter === 'all' || activity.status === selectedFilter;
-      return matchesSearch && matchesFilter;
+      const matchesStatusFilter = selectedFilter === 'all' || activity.status === selectedFilter;
+      const matchesTypeFilter = selectedTypeFilter === 'all' || activity.type === selectedTypeFilter;
+      
+      return matchesSearch && matchesStatusFilter && matchesTypeFilter;
     });
-  }, [activities, lowerSearchQuery, selectedFilter]);
+  }, [activities, lowerSearchQuery, selectedFilter, selectedTypeFilter]);
 
-  // Count activities by status
+  // Count activities by status and type
   const activityCounts = useMemo(() => {
     return {
       all: activities.length,
       active: activities.filter(a => a.status === 'active').length,
-      completed: activities.filter(a => a.status === 'completed').length
+      completed: activities.filter(a => a.status === 'completed').length,
+      unitary: activities.filter(a => a.type === 'unitary').length,
+      broadcast: activities.filter(a => a.type === 'broadcast').length
     };
   }, [activities]);
 
@@ -93,7 +98,7 @@ function ActivityList({
             width="100%"
           />
           
-          {/* Filters */}
+          {/* Status Filters */}
           <ActionGroup
             selectionMode="single"
             selectedKeys={[selectedFilter]}
@@ -109,6 +114,27 @@ function ActivityList({
               {formatMessage(activitiesMessages.completedActivities)} ({activityCounts.completed})
             </Item>
           </ActionGroup>
+          
+          {/* Type Filters */}
+          <Flex alignItems="center" gap="size-100">
+            <Text UNSAFE_className={classNames('filterLabel')}>Type:</Text>
+            <ActionGroup
+              selectionMode="single"
+              selectedKeys={[selectedTypeFilter]}
+              onSelectionChange={(keys) => setSelectedTypeFilter(Array.from(keys)[0] as 'all' | 'unitary' | 'broadcast')}
+              density="compact"
+            >
+              <Item key="all">
+                All ({activityCounts.all})
+              </Item>
+              <Item key="unitary">
+                🎮 Unitary ({activityCounts.unitary})
+              </Item>
+              <Item key="broadcast">
+                📡 Broadcast ({activityCounts.broadcast})
+              </Item>
+            </ActionGroup>
+          </Flex>
         </Flex>
 
         {/* Activities List */}
@@ -132,9 +158,9 @@ function ActivityList({
             <Flex direction="column" gap="size-50">
               {filteredActivities.map(activity => (
                 <ActivityCard
-                  key={activity.id}
+                  key={getActivityKey(activity)}
                   activity={activity}
-                  isSelected={selectedActivityId === activity.id}
+                  isSelected={selectedActivityId === getActivityKey(activity)}
                   onSelect={onActivitySelect}
                 />
               ))}

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
@@ -56,16 +56,35 @@ function ActivityList({
     });
   }, [activities, lowerSearchQuery, selectedFilter, selectedTypeFilter]);
 
-  // Count activities by status and type
-  const activityCounts = useMemo(() => {
+  // Count activities by status (total counts)
+  const statusCounts = useMemo(() => {
     return {
       all: activities.length,
       active: activities.filter(a => a.status === 'active').length,
-      completed: activities.filter(a => a.status === 'completed').length,
-      unitary: activities.filter(a => a.type === 'unitary').length,
-      broadcast: activities.filter(a => a.type === 'broadcast').length
+      completed: activities.filter(a => a.status === 'completed').length
     };
   }, [activities]);
+
+  // Count activities by type (reflecting search and status filters, but not type filter)
+  const typeCounts = useMemo(() => {
+    const activitiesAfterSearchAndStatus = activities.filter(activity => {
+      const matchesSearch = searchQuery === '' ||
+        activity.name.toLowerCase().includes(lowerSearchQuery) ||
+        activity.attributes?.toLowerCase().includes(lowerSearchQuery) ||
+        activity.id?.toLowerCase().includes(lowerSearchQuery) ||
+        activity.broadcastChannelId?.toLowerCase().includes(lowerSearchQuery);
+      
+      const matchesStatusFilter = selectedFilter === 'all' || activity.status === selectedFilter;
+      
+      return matchesSearch && matchesStatusFilter;
+    });
+    
+    return {
+      all: activitiesAfterSearchAndStatus.length,
+      unitary: activitiesAfterSearchAndStatus.filter(a => a.type === 'unitary').length,
+      broadcast: activitiesAfterSearchAndStatus.filter(a => a.type === 'broadcast').length
+    };
+  }, [activities, lowerSearchQuery, searchQuery, selectedFilter]);
 
   if (isLoading) {
     return (
@@ -105,13 +124,13 @@ function ActivityList({
             onSelectionChange={(keys) => setSelectedFilter(Array.from(keys)[0] as string)}
           >
             <Item key="all">
-              {formatMessage(activitiesMessages.allActivities)} ({activityCounts.all})
+              {formatMessage(activitiesMessages.allActivities)} ({statusCounts.all})
             </Item>
             <Item key="active">
-              {formatMessage(activitiesMessages.activeActivities)} ({activityCounts.active})
+              {formatMessage(activitiesMessages.activeActivities)} ({statusCounts.active})
             </Item>
             <Item key="completed">
-              {formatMessage(activitiesMessages.completedActivities)} ({activityCounts.completed})
+              {formatMessage(activitiesMessages.completedActivities)} ({statusCounts.completed})
             </Item>
           </ActionGroup>
           
@@ -125,13 +144,13 @@ function ActivityList({
               density="compact"
             >
               <Item key="all">
-                All ({activityCounts.all})
+                All ({typeCounts.all})
               </Item>
               <Item key="unitary">
-                🎮 Unitary ({activityCounts.unitary})
+                🎮 Unitary ({typeCounts.unitary})
               </Item>
               <Item key="broadcast">
-                📡 Broadcast ({activityCounts.broadcast})
+                📡 Broadcast ({typeCounts.broadcast})
               </Item>
             </ActionGroup>
           </Flex>

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
@@ -14,6 +14,7 @@ import React, { useState, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import classNames from 'classnames';
 
+import { ACTIVITY_TYPE, ActivityType } from '../../api/liveActivityApi';
 import { LiveActivity, getActivityKey } from '../../hooks/useActivities';
 import { activitiesMessages } from '../../i18n';
 
@@ -38,7 +39,7 @@ function ActivityList({
   const { formatMessage } = useIntl();
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedFilter, setSelectedFilter] = useState<string>('all');
-  const [selectedTypeFilter, setSelectedTypeFilter] = useState<'all' | 'unitary' | 'broadcast'>(
+  const [selectedTypeFilter, setSelectedTypeFilter] = useState<'all' | ActivityType>(
     'all'
   );
 
@@ -106,14 +107,14 @@ function ActivityList({
             <Picker
               label="Type"
               selectedKey={selectedTypeFilter}
-              onSelectionChange={key => setSelectedTypeFilter(key as 'all' | 'unitary' | 'broadcast')}
+              onSelectionChange={key => setSelectedTypeFilter(key as 'all' | ActivityType)}
               width="size-3000"
             >
               <Item key="all">
                 <Text>{formatMessage(activitiesMessages.allActivities)}</Text>
               </Item>
-              <Item key="unitary"><Text>{formatMessage(activitiesMessages.typeUnitary)}</Text></Item>
-              <Item key="broadcast"><Text>{formatMessage(activitiesMessages.typeBroadcast)}</Text></Item>
+              <Item key={ACTIVITY_TYPE.UNITARY}><Text>{formatMessage(activitiesMessages.typeUnitary)}</Text></Item>
+              <Item key={ACTIVITY_TYPE.BROADCAST}><Text>{formatMessage(activitiesMessages.typeBroadcast)}</Text></Item>
             </Picker>
 
             {/* Status Filter Dropdown */}

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
@@ -44,7 +44,10 @@ function ActivityList({
   const filteredActivities = useMemo(() => {
     return activities.filter(activity => {
       const matchesSearch = activity.name.toLowerCase().includes(lowerSearchQuery) ||
-                           activity.attributes?.toLowerCase().includes(lowerSearchQuery);
+                           activity.attributes?.toLowerCase().includes(lowerSearchQuery) ||
+                           activity.id?.toLowerCase().includes(lowerSearchQuery)
+                           activity.broadcastChannelId?.toLowerCase().includes(lowerSearchQuery);
+                           
       const matchesFilter = selectedFilter === 'all' || activity.status === selectedFilter;
       return matchesSearch && matchesFilter;
     });

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
@@ -14,7 +14,7 @@ import React, { useState, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import classNames from 'classnames';
 
-import { ACTIVITY_TYPE, ActivityType } from '../../api/liveActivityApi';
+import { ACTIVITY_TYPE, ActivityType } from '../../constants/liveActivitiesConfig';
 import { LiveActivity, getActivityKey } from '../../hooks/useActivities';
 import { activitiesMessages } from '../../i18n';
 
@@ -105,7 +105,7 @@ function ActivityList({
           <Flex alignItems="end" gap="size-200">
             {/* Type Filter Dropdown */}
             <Picker
-              label="Type"
+              label={formatMessage(activitiesMessages.typeFilterLabel)}
               selectedKey={selectedTypeFilter}
               onSelectionChange={key => setSelectedTypeFilter(key as 'all' | ActivityType)}
               width="size-3000"
@@ -119,7 +119,7 @@ function ActivityList({
 
             {/* Status Filter Dropdown */}
             <Picker
-              label="Status"
+              label={formatMessage(activitiesMessages.statusFilterLabel)}
               selectedKey={selectedFilter}
               onSelectionChange={key => setSelectedFilter(key as string)}
               width="size-3000"

--- a/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
+++ b/packages/ui-plugins/live-activities/src/components/activities/ActivityList.tsx
@@ -1,12 +1,12 @@
-import { 
-  Flex, 
-  SearchField, 
-  ActionGroup, 
-  Item, 
-  Text, 
+import {
+  Flex,
+  SearchField,
+  Item,
+  Text,
   Heading,
   View,
-  ProgressCircle
+  ProgressCircle,
+  Picker
 } from '@adobe/react-spectrum';
 
 import React, { useState, useMemo } from 'react';
@@ -27,16 +27,18 @@ interface ActivityListProps {
   isLoading?: boolean;
 }
 
-function ActivityList({ 
-  activities, 
-  selectedActivityId, 
-  onActivitySelect, 
-  isLoading = false 
+function ActivityList({
+  activities,
+  selectedActivityId,
+  onActivitySelect,
+  isLoading = false
 }: ActivityListProps) {
   const { formatMessage } = useIntl();
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedFilter, setSelectedFilter] = useState<string>('all');
-  const [selectedTypeFilter, setSelectedTypeFilter] = useState<'all' | 'unitary' | 'broadcast'>('all');
+  const [selectedTypeFilter, setSelectedTypeFilter] = useState<'all' | 'unitary' | 'broadcast'>(
+    'all'
+  );
 
   // Memoize lowercase search query to avoid repeated conversions
   const lowerSearchQuery = useMemo(() => searchQuery.toLowerCase(), [searchQuery]);
@@ -44,14 +46,16 @@ function ActivityList({
   // Memoized filtering logic
   const filteredActivities = useMemo(() => {
     return activities.filter(activity => {
-      const matchesSearch = activity.name.toLowerCase().includes(lowerSearchQuery) ||
-                           activity.attributes?.toLowerCase().includes(lowerSearchQuery) ||
-                           activity.id?.toLowerCase().includes(lowerSearchQuery) ||
-                           activity.broadcastChannelId?.toLowerCase().includes(lowerSearchQuery);
-                           
+      const matchesSearch =
+        activity.name.toLowerCase().includes(lowerSearchQuery) ||
+        activity.attributes?.toLowerCase().includes(lowerSearchQuery) ||
+        activity.id?.toLowerCase().includes(lowerSearchQuery) ||
+        activity.broadcastChannelId?.toLowerCase().includes(lowerSearchQuery);
+
       const matchesStatusFilter = selectedFilter === 'all' || activity.status === selectedFilter;
-      const matchesTypeFilter = selectedTypeFilter === 'all' || activity.type === selectedTypeFilter;
-      
+      const matchesTypeFilter =
+        selectedTypeFilter === 'all' || activity.type === selectedTypeFilter;
+
       return matchesSearch && matchesStatusFilter && matchesTypeFilter;
     });
   }, [activities, lowerSearchQuery, selectedFilter, selectedTypeFilter]);
@@ -68,17 +72,18 @@ function ActivityList({
   // Count activities by type (reflecting search and status filters, but not type filter)
   const typeCounts = useMemo(() => {
     const activitiesAfterSearchAndStatus = activities.filter(activity => {
-      const matchesSearch = searchQuery === '' ||
+      const matchesSearch =
+        searchQuery === '' ||
         activity.name.toLowerCase().includes(lowerSearchQuery) ||
         activity.attributes?.toLowerCase().includes(lowerSearchQuery) ||
         activity.id?.toLowerCase().includes(lowerSearchQuery) ||
         activity.broadcastChannelId?.toLowerCase().includes(lowerSearchQuery);
-      
+
       const matchesStatusFilter = selectedFilter === 'all' || activity.status === selectedFilter;
-      
+
       return matchesSearch && matchesStatusFilter;
     });
-    
+
     return {
       all: activitiesAfterSearchAndStatus.length,
       unitary: activitiesAfterSearchAndStatus.filter(a => a.type === 'unitary').length,
@@ -116,61 +121,57 @@ function ActivityList({
             onChange={setSearchQuery}
             width="100%"
           />
-          
-          {/* Status Filters */}
-          <ActionGroup
-            selectionMode="single"
-            selectedKeys={[selectedFilter]}
-            onSelectionChange={(keys) => setSelectedFilter(Array.from(keys)[0] as string)}
-          >
-            <Item key="all">
-              {formatMessage(activitiesMessages.allActivities)} ({statusCounts.all})
-            </Item>
-            <Item key="active">
-              {formatMessage(activitiesMessages.activeActivities)} ({statusCounts.active})
-            </Item>
-            <Item key="completed">
-              {formatMessage(activitiesMessages.completedActivities)} ({statusCounts.completed})
-            </Item>
-          </ActionGroup>
-          
-          {/* Type Filters */}
-          <Flex alignItems="center" gap="size-100">
-            <Text UNSAFE_className={classNames('filterLabel')}>Type:</Text>
-            <ActionGroup
-              selectionMode="single"
-              selectedKeys={[selectedTypeFilter]}
-              onSelectionChange={(keys) => setSelectedTypeFilter(Array.from(keys)[0] as 'all' | 'unitary' | 'broadcast')}
-              density="compact"
+
+          {/* Filters Row */}
+          <Flex alignItems="end" gap="size-200">
+            {/* Type Filter Dropdown */}
+            <Picker
+              label="Type"
+              selectedKey={selectedTypeFilter}
+              onSelectionChange={key => setSelectedTypeFilter(key as 'all' | 'unitary' | 'broadcast')}
+              width="size-3000"
             >
               <Item key="all">
-                All ({typeCounts.all})
+                <Text>All</Text>
               </Item>
-              <Item key="unitary">
-                🎮 Unitary ({typeCounts.unitary})
+              <Item key="unitary"><Text>Unitary</Text></Item>
+              <Item key="broadcast"><Text>Broadcast</Text></Item>
+            </Picker>
+
+            {/* Status Filter Dropdown */}
+            <Picker
+              label="Status"
+              selectedKey={selectedFilter}
+              onSelectionChange={key => setSelectedFilter(key as string)}
+              width="size-3000"
+            >
+              <Item key="all">
+                <Text>{formatMessage(activitiesMessages.allActivities)}</Text>
               </Item>
-              <Item key="broadcast">
-                📡 Broadcast ({typeCounts.broadcast})
+              <Item key="active">
+                <Text>{formatMessage(activitiesMessages.activeActivities)}</Text> 
               </Item>
-            </ActionGroup>
+              <Item key="completed">
+                <Text>{formatMessage(activitiesMessages.completedActivities)}</Text> 
+              </Item>
+            </Picker>
           </Flex>
         </Flex>
 
         {/* Activities List */}
         <View flex="1" overflow="auto">
           {filteredActivities.length === 0 ? (
-            <Flex 
-              justifyContent="center" 
-              alignItems="center" 
+            <Flex
+              justifyContent="center"
+              alignItems="center"
               height="size-2000"
               direction="column"
               gap="size-100"
             >
               <Text UNSAFE_className={classNames('noActivitiesText')}>
-                {searchQuery || selectedFilter !== 'all' 
+                {searchQuery || selectedFilter !== 'all'
                   ? formatMessage(activitiesMessages.noActivitiesFound)
-                  : formatMessage(activitiesMessages.noActivitiesAvailable)
-                }
+                  : formatMessage(activitiesMessages.noActivitiesAvailable)}
               </Text>
             </Flex>
           ) : (

--- a/packages/ui-plugins/live-activities/src/components/live-activity/__tests__/launch-live-activity.test.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/__tests__/launch-live-activity.test.tsx
@@ -650,5 +650,272 @@ describe('LaunchLiveActivity', () => {
       });
     });
   });
+
+  describe('Broadcast Functionality', () => {
+    it('should display activity type radio group with unitary and broadcast options', async () => {
+      render(
+        <TestWrapper>
+          <LaunchLiveActivity />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Start Live Activity/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Check for activity type radio buttons
+      expect(screen.getByRole('radio', { name: /Unitary/i })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /Broadcast/i })).toBeInTheDocument();
+      
+      // Unitary should be selected by default
+      expect(screen.getByRole('radio', { name: /Unitary/i })).toBeChecked();
+    });
+
+    it('should show broadcast channel ID field when broadcast type is selected', async () => {
+      render(
+        <TestWrapper>
+          <LaunchLiveActivity />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Start Live Activity/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Initially, broadcast channel ID field should not be visible (unitary is default)
+      expect(screen.queryByLabelText(/Broadcast Channel ID/i)).not.toBeInTheDocument();
+
+      // Select broadcast type
+      const broadcastRadio = screen.getByRole('radio', { name: /Broadcast/i });
+      fireEvent.click(broadcastRadio);
+
+      // Now broadcast channel ID field should be visible
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Broadcast Channel ID/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should hide broadcast channel ID field when switching back to unitary', async () => {
+      render(
+        <TestWrapper>
+          <LaunchLiveActivity />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Start Live Activity/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Select broadcast type
+      const broadcastRadio = screen.getByRole('radio', { name: /Broadcast/i });
+      fireEvent.click(broadcastRadio);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Broadcast Channel ID/i)).toBeInTheDocument();
+      });
+
+      // Switch back to unitary
+      const unitaryRadio = screen.getByRole('radio', { name: /Unitary/i });
+      fireEvent.click(unitaryRadio);
+
+      // Broadcast channel ID field should be hidden
+      await waitFor(() => {
+        expect(screen.queryByLabelText(/Broadcast Channel ID/i)).not.toBeInTheDocument();
+      });
+    });
+
+    it('should display broadcast channel ID field as required when broadcast type is selected', async () => {
+      render(
+        <TestWrapper>
+          <LaunchLiveActivity />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Start Live Activity/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Select broadcast type
+      const broadcastRadio = screen.getByRole('radio', { name: /Broadcast/i });
+      fireEvent.click(broadcastRadio);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Broadcast Channel ID/i)).toBeInTheDocument();
+      });
+
+      // Verify the field is marked as required
+      const channelIdField = screen.getByLabelText(/Broadcast Channel ID/i);
+      expect(channelIdField).toBeRequired();
+    });
+
+    it('should include broadcast channel ID in payload for broadcast activities', async () => {
+      mockSendLiveActivityNotification.mockResolvedValue(undefined);
+
+      render(
+        <TestWrapper>
+          <LaunchLiveActivity />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Start Live Activity/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Select activity
+      const pickerButton = screen.getByRole('button', { name: /Select Live Activity/i });
+      fireEvent.click(pickerButton);
+
+      await waitFor(() => {
+        const options = screen.getAllByText('TestActivity1');
+        fireEvent.click(options.at(-1)!);
+      });
+
+      // Select broadcast type
+      const broadcastRadio = screen.getByRole('radio', { name: /Broadcast/i });
+      fireEvent.click(broadcastRadio);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Broadcast Channel ID/i)).toBeInTheDocument();
+      });
+
+      // Enter broadcast channel ID
+      const channelIdField = screen.getByLabelText(/Broadcast Channel ID/i);
+      fireEvent.change(channelIdField, { target: { value: 'test-channel-123' } });
+
+      // Launch
+      await waitFor(async () => {
+        const dialogButtons = screen.getAllByRole('button', { name: /Start Live Activity/i });
+        const dialogLaunchButton = dialogButtons.at(-1)!;
+        
+        if (!dialogLaunchButton.hasAttribute('disabled')) {
+          fireEvent.click(dialogLaunchButton);
+        }
+      });
+
+      // Verify that buildCompleteApsPayload was called with broadcast channel ID
+      await waitFor(() => {
+        expect(mockBuildCompleteApsPayload).toHaveBeenCalledWith(
+          expect.objectContaining({
+            broadcastChannelId: 'test-channel-123',
+          })
+        );
+      });
+    });
+
+    it('should not include broadcast channel ID for unitary activities', async () => {
+      mockSendLiveActivityNotification.mockResolvedValue(undefined);
+
+      render(
+        <TestWrapper>
+          <LaunchLiveActivity />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Start Live Activity/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Select activity
+      const pickerButton = screen.getByRole('button', { name: /Select Live Activity/i });
+      fireEvent.click(pickerButton);
+
+      await waitFor(() => {
+        const options = screen.getAllByText('TestActivity1');
+        fireEvent.click(options.at(-1)!);
+      });
+
+      // Keep unitary type (default)
+      const unitaryRadio = screen.getByRole('radio', { name: /Unitary/i });
+      expect(unitaryRadio).toBeChecked();
+
+      // Launch
+      await waitFor(async () => {
+        const dialogButtons = screen.getAllByRole('button', { name: /Start Live Activity/i });
+        const dialogLaunchButton = dialogButtons.at(-1)!;
+        
+        if (!dialogLaunchButton.hasAttribute('disabled')) {
+          fireEvent.click(dialogLaunchButton);
+        }
+      });
+
+      // Verify that buildCompleteApsPayload was called without broadcast channel ID
+      await waitFor(() => {
+        expect(mockBuildCompleteApsPayload).toHaveBeenCalledWith(
+          expect.objectContaining({
+            broadcastChannelId: undefined,
+          })
+        );
+      });
+    });
+
+    it('should reset broadcast channel ID when switching between activities', async () => {
+      render(
+        <TestWrapper>
+          <LaunchLiveActivity />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Start Live Activity/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Select broadcast type and enter channel ID
+      const broadcastRadio = screen.getByRole('radio', { name: /Broadcast/i });
+      fireEvent.click(broadcastRadio);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Broadcast Channel ID/i)).toBeInTheDocument();
+      });
+
+      const channelIdField = screen.getByLabelText(/Broadcast Channel ID/i);
+      fireEvent.change(channelIdField, { target: { value: 'test-channel-123' } });
+
+      expect(channelIdField).toHaveValue('test-channel-123');
+
+      // Close dialog
+      const cancelButton = screen.getByRole('button', { name: /Cancel/i });
+      fireEvent.click(cancelButton);
+
+      // Reopen dialog
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Select broadcast type again
+      const broadcastRadio2 = screen.getByRole('radio', { name: /Broadcast/i });
+      fireEvent.click(broadcastRadio2);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Broadcast Channel ID/i)).toBeInTheDocument();
+      });
+
+      // Channel ID should be reset
+      const channelIdField2 = screen.getByLabelText(/Broadcast Channel ID/i);
+      expect(channelIdField2).toHaveValue('');
+    });
+  });
 });
 

--- a/packages/ui-plugins/live-activities/src/components/live-activity/__tests__/update-activity.test.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/__tests__/update-activity.test.tsx
@@ -121,21 +121,6 @@ describe('UpdateActivity', () => {
       expect(button).toBeDisabled();
     });
 
-    it('should disable button when activity is completed', () => {
-      const completedActivity = {
-        ...mockActivity,
-        status: 'completed' as const,
-      };
-
-      render(
-        <TestWrapper>
-          <UpdateActivity activity={completedActivity} />
-        </TestWrapper>
-      );
-
-      const button = screen.getByRole('button', { name: /Send Update/i });
-      expect(button).toBeDisabled();
-    });
 
     it('should enable button when activity has update token and is active', () => {
       render(

--- a/packages/ui-plugins/live-activities/src/components/live-activity/__tests__/update-activity.test.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/__tests__/update-activity.test.tsx
@@ -12,6 +12,7 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import UpdateActivity from '../update-activity';
 import * as liveActivityApi from '../../../api/liveActivityApi';
 import { LiveActivity } from '../../../hooks/useActivities';
+import { ACTIVITY_TYPE } from '../../../constants/liveActivitiesConfig';
 
 // Mock the hooks
 vi.mock('../../../hooks/useLiveActivityContext', () => ({
@@ -975,6 +976,276 @@ describe('UpdateActivity', () => {
           })
         );
       });
+    });
+  });
+
+  describe('Broadcast Functionality', () => {
+    const mockBroadcastActivity = {
+      id: '',
+      name: 'FlightActivity',
+      attributes: 'FlightActivity',
+      broadcastChannelId: 'flight-channel-123',
+      type: ACTIVITY_TYPE.BROADCAST,
+      updateToken: undefined,
+      status: 'active' as const,
+      contentState: { flight: 'AA123' },
+    } as LiveActivity;
+
+    it('should enable button for broadcast activities even without update token', () => {
+      render(
+        <TestWrapper>
+          <UpdateActivity activity={mockBroadcastActivity} />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Send Update/i });
+      // Broadcast activities don't require update token
+      expect(button).not.toBeDisabled();
+    });
+
+    it('should display broadcast type radio button as selected and disabled', async () => {
+      render(
+        <TestWrapper>
+          <UpdateActivity activity={mockBroadcastActivity} />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Send Update/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Broadcast radio should be checked
+      const broadcastRadio = screen.getByRole('radio', { name: /Broadcast/i });
+      expect(broadcastRadio).toBeChecked();
+      
+      // Type selection should be disabled (can't change after activity starts)
+      expect(broadcastRadio).toBeDisabled();
+      
+      const unitaryRadio = screen.getByRole('radio', { name: /Unitary/i });
+      expect(unitaryRadio).toBeDisabled();
+    });
+
+    it('should display broadcast channel ID field as disabled with pre-filled value', async () => {
+      render(
+        <TestWrapper>
+          <UpdateActivity activity={mockBroadcastActivity} />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Send Update/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Broadcast channel ID field should be visible and disabled
+      const channelIdField = screen.getByLabelText(/Broadcast Channel ID/i);
+      expect(channelIdField).toBeInTheDocument();
+      expect(channelIdField).toBeDisabled();
+      expect(channelIdField).toHaveValue('flight-channel-123');
+    });
+
+    it('should display broadcast channel ID in dialog heading when id is empty', async () => {
+      render(
+        <TestWrapper>
+          <UpdateActivity activity={mockBroadcastActivity} />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Send Update/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Update Live Activity flight-channel-123/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should allow updates for completed broadcast activities', () => {
+      const completedBroadcastActivity = {
+        ...mockBroadcastActivity,
+        status: 'completed' as const,
+      };
+
+      render(
+        <TestWrapper>
+          <UpdateActivity activity={completedBroadcastActivity} />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Send Update/i });
+      // Broadcast channels can be reused, so button should be enabled
+      expect(button).not.toBeDisabled();
+    });
+
+    it('should allow updates for unitary activities with update token regardless of status', () => {
+      const completedUnitaryActivity = {
+        ...mockActivity,
+        type: ACTIVITY_TYPE.UNITARY,
+        status: 'completed' as const,
+        updateToken: 'some-token',
+      };
+
+      render(
+        <TestWrapper>
+          <UpdateActivity activity={completedUnitaryActivity} />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Send Update/i });
+      // Unitary activities can be updated if they have update token
+      expect(button).not.toBeDisabled();
+    });
+
+    it('should include broadcast channel ID in payload when updating broadcast activity', async () => {
+      mockSendLiveActivityNotification.mockResolvedValue(undefined);
+
+      render(
+        <TestWrapper>
+          <UpdateActivity activity={mockBroadcastActivity} />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Send Update/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Click update button in dialog
+      const dialog = screen.getByRole('dialog');
+      const dialogButtons = within(dialog).getAllByRole('button');
+      const updateButton = dialogButtons.find(btn => 
+        btn.textContent?.includes('Update') && !btn.hasAttribute('disabled')
+      );
+      
+      if (updateButton) {
+        fireEvent.click(updateButton);
+      }
+
+      await waitFor(() => {
+        expect(mockBuildCompleteApsPayload).toHaveBeenCalledWith(
+          expect.objectContaining({
+            broadcastChannelId: 'flight-channel-123',
+          })
+        );
+      });
+    });
+
+    it('should not require push-to-start token for broadcast updates', async () => {
+      mockSendLiveActivityNotification.mockResolvedValue(undefined);
+
+      render(
+        <TestWrapper>
+          <UpdateActivity activity={mockBroadcastActivity} />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Send Update/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Should be able to send update without token
+      const dialog = screen.getByRole('dialog');
+      const dialogButtons = within(dialog).getAllByRole('button');
+      const updateButton = dialogButtons.find(btn => 
+        btn.textContent?.includes('Update') && !btn.hasAttribute('disabled')
+      );
+      
+      expect(updateButton).not.toBeDisabled();
+    });
+
+    it('should use empty string as token for broadcast activities', async () => {
+      mockSendLiveActivityNotification.mockResolvedValue(undefined);
+
+      render(
+        <TestWrapper>
+          <UpdateActivity activity={mockBroadcastActivity} />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Send Update/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      const dialog = screen.getByRole('dialog');
+      const dialogButtons = within(dialog).getAllByRole('button');
+      const updateButton = dialogButtons.find(btn => 
+        btn.textContent?.includes('Update') && !btn.hasAttribute('disabled')
+      );
+      
+      if (updateButton) {
+        fireEvent.click(updateButton);
+      }
+
+      await waitFor(() => {
+        expect(mockGenerateLiveActivityPayload).toHaveBeenCalledWith(
+          expect.objectContaining({
+            token: '', // Broadcast uses empty token
+          })
+        );
+      });
+    });
+
+    it('should display unitary type radio button as selected and disabled for unitary activities', async () => {
+      const unitaryActivity = {
+        ...mockActivity,
+        type: ACTIVITY_TYPE.UNITARY,
+      };
+
+      render(
+        <TestWrapper>
+          <UpdateActivity activity={unitaryActivity} />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Send Update/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Unitary radio should be checked and disabled
+      const unitaryRadio = screen.getByRole('radio', { name: /Unitary/i });
+      expect(unitaryRadio).toBeChecked();
+      expect(unitaryRadio).toBeDisabled();
+      
+      const broadcastRadio = screen.getByRole('radio', { name: /Broadcast/i });
+      expect(broadcastRadio).toBeDisabled();
+    });
+
+    it('should not display broadcast channel ID field for unitary activities', async () => {
+      const unitaryActivity = {
+        ...mockActivity,
+        type: ACTIVITY_TYPE.UNITARY,
+      };
+
+      render(
+        <TestWrapper>
+          <UpdateActivity activity={unitaryActivity} />
+        </TestWrapper>
+      );
+
+      const button = screen.getByRole('button', { name: /Send Update/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Broadcast channel ID field should not be visible for unitary
+      expect(screen.queryByLabelText(/Broadcast Channel ID/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/ui-plugins/live-activities/src/components/live-activity/activity-event-details.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/activity-event-details.tsx
@@ -50,7 +50,7 @@ function ActivityEventDetails({ activity }: Readonly<ActivityEventDetailsProps>)
   const [detailsPanelOpen, setDetailsPanelOpen] = useState(false);
 
     // Use new event processing utilities
-    const activityEvents = useActivityEvents(activity?.id);
+    const activityEvents = useActivityEvents(activity?.id || activity?.broadcastChannelId);
     const eventStats = useEventStatistics(activityEvents);
     const timeRange = useEventTimeRange(activityEvents);
 

--- a/packages/ui-plugins/live-activities/src/components/live-activity/activity-event-details.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/activity-event-details.tsx
@@ -50,7 +50,7 @@ function ActivityEventDetails({ activity }: Readonly<ActivityEventDetailsProps>)
   const [detailsPanelOpen, setDetailsPanelOpen] = useState(false);
 
     // Use new event processing utilities
-    const activityEvents = useActivityEvents(activity ? getActivityKey(activity) : undefined);
+    const activityEvents = useActivityEvents(getActivityKey(activity));
     const eventStats = useEventStatistics(activityEvents);
     const timeRange = useEventTimeRange(activityEvents);
 

--- a/packages/ui-plugins/live-activities/src/components/live-activity/activity-event-details.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/activity-event-details.tsx
@@ -13,7 +13,7 @@ import { useIntl } from 'react-intl';
 import InfoField from '../atoms/InfoField';
 import MetricCard from '../atoms/MetricCard';
 import Card from '../atoms/card';
-import { LiveActivity } from '../../hooks/useActivities';
+import { LiveActivity, getActivityKey } from '../../hooks/useActivities';
 import usePluginState from '../../hooks/usePluginState';
 import { LiveActivityEvent } from '../../types/liveActivityEvent';
 import { useActivityEvents, useEventStatistics, useEventTimeRange, filterEventsByType, filterEventsBySearch } from '../../utils/eventProcessing';
@@ -50,7 +50,7 @@ function ActivityEventDetails({ activity }: Readonly<ActivityEventDetailsProps>)
   const [detailsPanelOpen, setDetailsPanelOpen] = useState(false);
 
     // Use new event processing utilities
-    const activityEvents = useActivityEvents(activity?.id || activity?.broadcastChannelId);
+    const activityEvents = useActivityEvents(activity ? getActivityKey(activity) : undefined);
     const eventStats = useEventStatistics(activityEvents);
     const timeRange = useEventTimeRange(activityEvents);
 

--- a/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
@@ -143,7 +143,7 @@ function ActivityOverview({ activity }: ActivityOverviewProps) {
                 <Divider />
                 <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                   <tbody>
-                    <InfoField
+                   {activity.id && <InfoField
                       label={formatMessage(activitiesMessages.liveActivityId)}
                       value={
                         <CopyableValue 
@@ -154,7 +154,22 @@ function ActivityOverview({ activity }: ActivityOverviewProps) {
                         />
                       }
                       wrap={true}
+                    />}
+
+                    {activity.broadcastChannelId && (
+                      <InfoField
+                      label={formatMessage(activitiesMessages.broadcastChannelId)}
+                      value={
+                        <CopyableValue 
+                          value={activity.broadcastChannelId}
+                          copyTooltip={formatMessage(copyMessages.copyValue)}
+                          copyFullValueTooltip={formatMessage(copyMessages.copyFullValue)}
+                          copiedMessage={formatMessage(copyMessages.copied)}
+                        />
+                      }
+                      wrap={true}
                     />
+                    )}
                     <InfoField
                       label={formatMessage(activitiesMessages.attributeSet)}
                       value={activity.attributes || 'N/A'}

--- a/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
@@ -12,6 +12,7 @@ import { CopyableValue } from '@assurance/common-utils';
 import InfoField from '../atoms/InfoField';
 import MetricCard from '../atoms/MetricCard';
 import Card from '../atoms/card';
+import { ACTIVITY_TYPE } from '../../api/liveActivityApi';
 import { LiveActivity, getActivityKey } from '../../hooks/useActivities';
 import { useActivityEvents } from '../../utils/eventProcessing';
 import { activitiesMessages, copyMessages, contentStateMessages } from '../../i18n';
@@ -83,7 +84,7 @@ function ActivityOverview({ activity }: ActivityOverviewProps) {
             <Heading level={2} marginY="size-0">
               {activity.name}
             </Heading>
-            {activity.type==="unitary" && <ActivityStatus status={activity.status} />}
+            {activity.type === ACTIVITY_TYPE.UNITARY && <ActivityStatus status={activity.status} />}
           </Flex>
           <UpdateActivity activity={activity} />
         </Flex>

--- a/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
@@ -12,7 +12,7 @@ import { CopyableValue } from '@assurance/common-utils';
 import InfoField from '../atoms/InfoField';
 import MetricCard from '../atoms/MetricCard';
 import Card from '../atoms/card';
-import { ACTIVITY_TYPE } from '../../api/liveActivityApi';
+import { ACTIVITY_TYPE } from '../../constants/liveActivitiesConfig';
 import { LiveActivity, getActivityKey } from '../../hooks/useActivities';
 import { useActivityEvents } from '../../utils/eventProcessing';
 import { activitiesMessages, copyMessages, contentStateMessages } from '../../i18n';
@@ -31,7 +31,7 @@ function ActivityOverview({ activity }: ActivityOverviewProps) {
   const { formatMessage } = useIntl();
 
   // Use the same deduplicated events as other components
-  const activityEvents = useActivityEvents(activity ? getActivityKey(activity) : undefined);
+  const activityEvents = useActivityEvents(getActivityKey(activity));
 
   // Get the latest content state from update events
   const { latestContentState, latestContentStateEventId } = useMemo(() => {
@@ -144,7 +144,7 @@ function ActivityOverview({ activity }: ActivityOverviewProps) {
                 <Divider />
                 <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                   <tbody>
-                   {activity.id && <InfoField
+                   {activity.id && activity.type === ACTIVITY_TYPE.UNITARY && <InfoField
                       label={formatMessage(activitiesMessages.liveActivityId)}
                       value={
                         <CopyableValue 
@@ -181,7 +181,7 @@ function ActivityOverview({ activity }: ActivityOverviewProps) {
                         value={startTime.format('lll')}
                       />
                     )}
-                    {endTime && (
+                    {endTime && activity.type === ACTIVITY_TYPE.UNITARY && (
                       <InfoField
                         label={formatMessage(activitiesMessages.endTime)}
                         value={endTime.format('lll')}

--- a/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
@@ -83,7 +83,7 @@ function ActivityOverview({ activity }: ActivityOverviewProps) {
             <Heading level={2} marginY="size-0">
               {activity.name}
             </Heading>
-            {activity.type==='unitary' && <ActivityStatus status={activity.status} />}
+            {activity.type==="unitary" && <ActivityStatus status={activity.status} />}
           </Flex>
           <UpdateActivity activity={activity} />
         </Flex>

--- a/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
@@ -12,7 +12,7 @@ import { CopyableValue } from '@assurance/common-utils';
 import InfoField from '../atoms/InfoField';
 import MetricCard from '../atoms/MetricCard';
 import Card from '../atoms/card';
-import { LiveActivity } from '../../hooks/useActivities';
+import { LiveActivity, getActivityKey } from '../../hooks/useActivities';
 import { useActivityEvents } from '../../utils/eventProcessing';
 import { activitiesMessages, copyMessages, contentStateMessages } from '../../i18n';
 
@@ -30,7 +30,7 @@ function ActivityOverview({ activity }: ActivityOverviewProps) {
   const { formatMessage } = useIntl();
 
   // Use the same deduplicated events as other components
-  const activityEvents = useActivityEvents(activity?.id || activity?.broadcastChannelId);
+  const activityEvents = useActivityEvents(activity ? getActivityKey(activity) : undefined);
 
   // Get the latest content state from update events
   const { latestContentState, latestContentStateEventId } = useMemo(() => {

--- a/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
@@ -30,7 +30,7 @@ function ActivityOverview({ activity }: ActivityOverviewProps) {
   const { formatMessage } = useIntl();
 
   // Use the same deduplicated events as other components
-  const activityEvents = useActivityEvents(activity?.id);
+  const activityEvents = useActivityEvents(activity?.id || activity?.broadcastChannelId);
 
   // Get the latest content state from update events
   const { latestContentState, latestContentStateEventId } = useMemo(() => {
@@ -44,7 +44,7 @@ function ActivityOverview({ activity }: ActivityOverviewProps) {
       latestContentState: updateEvent?.payload?.ACPExtensionEventData?.contentState,
       latestContentStateEventId: updateEvent?.uuid
     };
-  }, [activity?.id, activityEvents]);
+  }, [activity?.id || activity?.broadcastChannelId, activityEvents]);
 
   // Calculate duration
   const startTime = activity?.startTime ? dayjs(activity.startTime) : null;

--- a/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/activity-overview.tsx
@@ -83,7 +83,7 @@ function ActivityOverview({ activity }: ActivityOverviewProps) {
             <Heading level={2} marginY="size-0">
               {activity.name}
             </Heading>
-            <ActivityStatus status={activity.status} />
+            {activity.type==='unitary' && <ActivityStatus status={activity.status} />}
           </Flex>
           <UpdateActivity activity={activity} />
         </Flex>

--- a/packages/ui-plugins/live-activities/src/components/live-activity/common/JsonEditor.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/common/JsonEditor.tsx
@@ -83,7 +83,7 @@ export function JsonEditor({
   label,
   editorRef,
   showLineNumbers = false,
-  height = '400px',
+  height = '300px',
   className
 }: Readonly<JsonEditorProps>) {
   const editorOptions = showLineNumbers

--- a/packages/ui-plugins/live-activities/src/components/live-activity/launch-live-activity.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/launch-live-activity.tsx
@@ -27,12 +27,15 @@ import {
   generateLiveActivityPayload,
   sendLiveActivityNotification,
   generateLaunchTemplate,
-  buildCompleteApsPayload,
+  buildCompleteApsPayload
+} from '../../api/liveActivityApi';
+import { 
+  LIVE_ACTIVITY_DEFAULTS, 
+  MESSAGES as COMMON_MESSAGES,
   ACTIVITY_TYPE,
   ActivityType,
   EVENT_TYPE
-} from '../../api/liveActivityApi';
-import { LIVE_ACTIVITY_DEFAULTS, MESSAGES as COMMON_MESSAGES } from '../../constants/liveActivitiesConfig';
+} from '../../constants/liveActivitiesConfig';
 import { ErrorMessage, JsonEditor, DialogActions } from './common';
 import { useLiveActivityContext } from '../../hooks/useLiveActivityContext';
 import { liveActivityMessages } from '../../i18n';
@@ -84,7 +87,7 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
   const { formatMessage } = useIntl();
   
   // State
-  const [selectedActivityType, setSelectedActivityType] = useState<string>('');
+  const [selectedAttributeType, setSelectedAttributeType] = useState<string>('');
   const [apsPayload, setApsPayload] = useState(
     JSON.stringify(generateLaunchTemplate(), null, 2)
   );
@@ -102,9 +105,9 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
   const context = useLiveActivityContext({ requirePushToken: true });
   // Get selected activity details
   const selectedActivity = registeredActivities.find(
-    (activity) => activity.attributeType === selectedActivityType
+    (activity) => activity.attributeType === selectedAttributeType
   );
-  const selectedLiveActivityData = liveActivitiesData.activityTypes.get(selectedActivityType);
+  const selectedLiveActivityData = liveActivitiesData.activityTypes.get(selectedAttributeType);
 
   
   // Get push to start token from live activities data
@@ -134,12 +137,15 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
         throw new Error(formatMessage(liveActivityMessages.broadcastChannelIdRequired));
       }
 
+      // Determine broadcast channel ID based on activity type
+      const channelIdToSend = activityTypeSelection === ACTIVITY_TYPE.BROADCAST ? broadcastChannelId : undefined;
+
       // Build complete APS payload by merging user input with auto-generated fields
       const completeApsPayload = buildCompleteApsPayload({
         userPayload,
         eventType: EVENT_TYPE.START,
-        attributesType: selectedActivityType,
-        broadcastChannelId: activityTypeSelection === ACTIVITY_TYPE.BROADCAST ? broadcastChannelId : undefined
+        attributesType: selectedAttributeType,
+        broadcastChannelId: channelIdToSend
       });
 
       // Generate complete payload
@@ -154,7 +160,7 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
         sandboxName: context.sandbox?.name || LIVE_ACTIVITY_DEFAULTS.SANDBOX,
         environment: context.environment,
         type: activityTypeSelection,
-        broadcastChannelId: activityTypeSelection === ACTIVITY_TYPE.BROADCAST ? broadcastChannelId : undefined
+        broadcastChannelId: channelIdToSend
       });
 
       // Make API call
@@ -172,10 +178,10 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
     } finally {
       setIsLoading(false);
     }
-  }, [apsPayload, context, selectedActivity, pushToStartToken, selectedActivityType, activityTypeSelection, broadcastChannelId, formatMessage]);
+  }, [apsPayload, context, selectedActivity, pushToStartToken, selectedAttributeType, activityTypeSelection, broadcastChannelId]);
 
   const handleReset = useCallback(() => {
-    setSelectedActivityType('');
+    setSelectedAttributeType('');
     setApsPayload(JSON.stringify(generateLaunchTemplate(), null, 2));
     setActivityTypeSelection(ACTIVITY_TYPE.UNITARY);
     setBroadcastChannelId('');
@@ -199,7 +205,7 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
 
   // Computed values
   const hasRegisteredActivities = registeredActivities.length > 0;
-  const canSubmit = selectedActivityType && 
+  const canSubmit = selectedAttributeType && 
                     apsPayload.trim() !== '' && 
                     context.isReady && 
                     !isLoading &&
@@ -256,8 +262,8 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
 
             <ActivityPicker
               activities={registeredActivities}
-              selectedKey={selectedActivityType}
-              onSelectionChange={setSelectedActivityType}
+              selectedKey={selectedAttributeType}
+              onSelectionChange={setSelectedAttributeType}
               label={formatMessage(liveActivityMessages.selectActivity)}
             />
 

--- a/packages/ui-plugins/live-activities/src/components/live-activity/launch-live-activity.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/launch-live-activity.tsx
@@ -10,7 +10,10 @@ import {
   Text,
   Picker,
   Item,
-  ToastQueue
+  ToastQueue,
+  RadioGroup,
+  Radio,
+  TextField
 } from '@adobe/react-spectrum';
 import classNames from 'classnames';
 import Rocket from '@spectrum-icons/workflow/Launch';
@@ -77,6 +80,8 @@ function LaunchLiveActivity() {
   );
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [activityTypeSelection, setActivityTypeSelection] = useState<'unitary' | 'broadcast'>('unitary');
+  const [broadcastChannelId, setBroadcastChannelId] = useState<string>('');
   const editorRef = useRef<any>(null);
 
   // Live Activities Data
@@ -114,11 +119,17 @@ function LaunchLiveActivity() {
         throw new Error('Please select a live activity with push-to-start token');
       }
 
+      // Validate broadcast channel ID if broadcast type is selected
+      if (activityTypeSelection === 'broadcast' && !broadcastChannelId.trim()) {
+        throw new Error(formatMessage(liveActivityMessages.broadcastChannelIdRequired));
+      }
+
       // Build complete APS payload by merging user input with auto-generated fields
       const completeApsPayload = buildCompleteApsPayload({
         userPayload,
         eventType: 'start',
-        attributesType: selectedActivityType
+        attributesType: selectedActivityType,
+        broadcastChannelId: activityTypeSelection === 'broadcast' ? broadcastChannelId : undefined
       });
 
       // Generate complete payload
@@ -131,7 +142,9 @@ function LaunchLiveActivity() {
         imsOrg: context.imsOrg!,
         sessionId: context.sessionId!,
         sandboxName: context.sandbox?.name || LIVE_ACTIVITY_DEFAULTS.SANDBOX,
-        environment: context.environment
+        environment: context.environment,
+        type: activityTypeSelection,
+        broadcastChannelId: activityTypeSelection === 'broadcast' ? broadcastChannelId : undefined
       });
 
       // Make API call
@@ -149,11 +162,13 @@ function LaunchLiveActivity() {
     } finally {
       setIsLoading(false);
     }
-  }, [apsPayload, context, selectedActivity, pushToStartToken, selectedActivityType]);
+  }, [apsPayload, context, selectedActivity, pushToStartToken, selectedActivityType, activityTypeSelection, broadcastChannelId, formatMessage]);
 
   const handleReset = useCallback(() => {
     setSelectedActivityType('');
     setApsPayload(JSON.stringify(generateLaunchTemplate(), null, 2));
+    setActivityTypeSelection('unitary');
+    setBroadcastChannelId('');
     setError(null);
   }, []);
 
@@ -174,7 +189,11 @@ function LaunchLiveActivity() {
 
   // Computed values
   const hasRegisteredActivities = registeredActivities.length > 0;
-  const canSubmit = selectedActivityType && apsPayload.trim() !== '' && context.isReady && !isLoading;
+  const canSubmit = selectedActivityType && 
+                    apsPayload.trim() !== '' && 
+                    context.isReady && 
+                    !isLoading &&
+                    (activityTypeSelection === 'unitary' || (activityTypeSelection === 'broadcast' && broadcastChannelId.trim() !== ''));
   const isButtonDisabled = !context.isReady || isLoading || !hasRegisteredActivities;
   const buttonTooltip = hasRegisteredActivities 
     ? formatMessage(liveActivityMessages.launchLiveActivity)
@@ -208,6 +227,31 @@ function LaunchLiveActivity() {
               onSelectionChange={setSelectedActivityType}
               label={formatMessage(liveActivityMessages.selectActivity)}
             />
+
+            <View marginBottom="size-200">
+              <RadioGroup 
+                label={formatMessage(liveActivityMessages.activityType)}
+                value={activityTypeSelection}
+                onChange={(value) => setActivityTypeSelection(value as 'unitary' | 'broadcast')}
+                orientation="horizontal"
+              >
+                <Radio value="unitary">{formatMessage(liveActivityMessages.activityTypeUnitary)}</Radio>
+                <Radio value="broadcast">{formatMessage(liveActivityMessages.activityTypeBroadcast)}</Radio>
+              </RadioGroup>
+            </View>
+
+            {activityTypeSelection === 'broadcast' && (
+              <View marginBottom="size-200">
+                <TextField
+                  label={formatMessage(liveActivityMessages.broadcastChannelId)}
+                  placeholder={formatMessage(liveActivityMessages.broadcastChannelIdPlaceholder)}
+                  value={broadcastChannelId}
+                  onChange={setBroadcastChannelId}
+                  width="100%"
+                  isRequired
+                />
+              </View>
+            )}
 
             <JsonEditor
               value={apsPayload}

--- a/packages/ui-plugins/live-activities/src/components/live-activity/launch-live-activity.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/launch-live-activity.tsx
@@ -252,14 +252,12 @@ function LaunchLiveActivity() {
                 />
               </View>
             )}
-
             <JsonEditor
               value={apsPayload}
               onChange={(val) => setApsPayload(val || '{}')}
               editorRef={editorRef}
               className={classNames('editorContainer')}
             />
-
             {error && <ErrorMessage message={error} />}
           </Content>
           

--- a/packages/ui-plugins/live-activities/src/components/live-activity/launch-live-activity.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/launch-live-activity.tsx
@@ -27,7 +27,10 @@ import {
   generateLiveActivityPayload,
   sendLiveActivityNotification,
   generateLaunchTemplate,
-  buildCompleteApsPayload
+  buildCompleteApsPayload,
+  ACTIVITY_TYPE,
+  ActivityType,
+  EVENT_TYPE
 } from '../../api/liveActivityApi';
 import { LIVE_ACTIVITY_DEFAULTS, MESSAGES as COMMON_MESSAGES } from '../../constants/liveActivitiesConfig';
 import { ErrorMessage, JsonEditor, DialogActions } from './common';
@@ -87,7 +90,7 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
   );
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [activityTypeSelection, setActivityTypeSelection] = useState<'unitary' | 'broadcast'>('unitary');
+  const [activityTypeSelection, setActivityTypeSelection] = useState<ActivityType>(ACTIVITY_TYPE.UNITARY);
   const [broadcastChannelId, setBroadcastChannelId] = useState<string>('');
   const editorRef = useRef<any>(null);
 
@@ -127,16 +130,16 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
       }
 
       // Validate broadcast channel ID if broadcast type is selected
-      if (activityTypeSelection === 'broadcast' && !broadcastChannelId.trim()) {
+      if (activityTypeSelection === ACTIVITY_TYPE.BROADCAST && !broadcastChannelId.trim()) {
         throw new Error(formatMessage(liveActivityMessages.broadcastChannelIdRequired));
       }
 
       // Build complete APS payload by merging user input with auto-generated fields
       const completeApsPayload = buildCompleteApsPayload({
         userPayload,
-        eventType: 'start',
+        eventType: EVENT_TYPE.START,
         attributesType: selectedActivityType,
-        broadcastChannelId: activityTypeSelection === 'broadcast' ? broadcastChannelId : undefined
+        broadcastChannelId: activityTypeSelection === ACTIVITY_TYPE.BROADCAST ? broadcastChannelId : undefined
       });
 
       // Generate complete payload
@@ -151,7 +154,7 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
         sandboxName: context.sandbox?.name || LIVE_ACTIVITY_DEFAULTS.SANDBOX,
         environment: context.environment,
         type: activityTypeSelection,
-        broadcastChannelId: activityTypeSelection === 'broadcast' ? broadcastChannelId : undefined
+        broadcastChannelId: activityTypeSelection === ACTIVITY_TYPE.BROADCAST ? broadcastChannelId : undefined
       });
 
       // Make API call
@@ -174,7 +177,7 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
   const handleReset = useCallback(() => {
     setSelectedActivityType('');
     setApsPayload(JSON.stringify(generateLaunchTemplate(), null, 2));
-    setActivityTypeSelection('unitary');
+    setActivityTypeSelection(ACTIVITY_TYPE.UNITARY);
     setBroadcastChannelId('');
     setError(null);
   }, []);
@@ -200,7 +203,7 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
                     apsPayload.trim() !== '' && 
                     context.isReady && 
                     !isLoading &&
-                    (activityTypeSelection === 'unitary' || (activityTypeSelection === 'broadcast' && broadcastChannelId.trim() !== ''));
+                    (activityTypeSelection === ACTIVITY_TYPE.UNITARY || (activityTypeSelection === ACTIVITY_TYPE.BROADCAST && broadcastChannelId.trim() !== ''));
   const isButtonDisabled = !context.isReady || isLoading || !hasRegisteredActivities;
   const buttonTooltip = hasRegisteredActivities 
     ? formatMessage(liveActivityMessages.launchLiveActivity)
@@ -262,15 +265,15 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
               <RadioGroup 
                 label={formatMessage(liveActivityMessages.activityType)}
                 value={activityTypeSelection}
-                onChange={(value) => setActivityTypeSelection(value as 'unitary' | 'broadcast')}
+                onChange={(value) => setActivityTypeSelection(value as ActivityType)}
                 orientation="horizontal"
               >
-                <Radio value="unitary">{formatMessage(liveActivityMessages.activityTypeUnitary)}</Radio>
-                <Radio value="broadcast">{formatMessage(liveActivityMessages.activityTypeBroadcast)}</Radio>
+                <Radio value={ACTIVITY_TYPE.UNITARY}>{formatMessage(liveActivityMessages.activityTypeUnitary)}</Radio>
+                <Radio value={ACTIVITY_TYPE.BROADCAST}>{formatMessage(liveActivityMessages.activityTypeBroadcast)}</Radio>
               </RadioGroup>
             </View>
 
-            {activityTypeSelection === 'broadcast' && (
+            {activityTypeSelection === ACTIVITY_TYPE.BROADCAST && (
               <View marginBottom="size-200">
                 <TextField
                   label={formatMessage(liveActivityMessages.broadcastChannelId)}

--- a/packages/ui-plugins/live-activities/src/components/live-activity/launch-live-activity.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/launch-live-activity.tsx
@@ -215,7 +215,7 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
           <Button 
             variant="cta" 
             isDisabled={isButtonDisabled}
-            aria-label={buttonTooltip}
+            aria-label={formatMessage(liveActivityMessages.launchNewLiveActivity)}
             UNSAFE_style={{
               padding: '8px',
               minWidth: 'max-content',
@@ -226,7 +226,7 @@ function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
             <Add size='XS' />
           </Button>
           <Tooltip>
-            <Text>Start a new live activity</Text>
+            <Text>{formatMessage(liveActivityMessages.launchNewLiveActivity)}</Text>
           </Tooltip>
         </TooltipTrigger>
       ) : (

--- a/packages/ui-plugins/live-activities/src/components/live-activity/launch-live-activity.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/launch-live-activity.tsx
@@ -13,10 +13,13 @@ import {
   ToastQueue,
   RadioGroup,
   Radio,
-  TextField
+  TextField,
+  TooltipTrigger,
+  Tooltip
 } from '@adobe/react-spectrum';
 import classNames from 'classnames';
 import Rocket from '@spectrum-icons/workflow/Launch';
+import Add from '@spectrum-icons/workflow/Add';
 import { useIntl } from 'react-intl';
 import { useLiveActivitiesData, useRegisteredActivities } from '../../hooks/useActivities';
 import {
@@ -70,7 +73,11 @@ function ActivityPicker({ activities, selectedKey, onSelectionChange, label }: R
 // MAIN COMPONENT
 // ============================================================================
 
-function LaunchLiveActivity() {
+interface LaunchLiveActivityProps {
+  compact?: boolean;
+}
+
+function LaunchLiveActivity({ compact = false }: LaunchLiveActivityProps) {
   const { formatMessage } = useIntl();
   
   // State
@@ -202,14 +209,37 @@ function LaunchLiveActivity() {
   // Render
   return (
     <DialogTrigger>
-      <Button 
-        variant="cta" 
-        isDisabled={isButtonDisabled}
-        aria-label={buttonTooltip}
-      >
-        <Rocket marginEnd="size-50" />
-        {formatMessage(liveActivityMessages.launchLiveActivity)}
-      </Button>
+      {compact ? (
+        // Compact mode: Icon-only button with tooltip
+        <TooltipTrigger delay={0}>
+          <Button 
+            variant="cta" 
+            isDisabled={isButtonDisabled}
+            aria-label={buttonTooltip}
+            UNSAFE_style={{
+              padding: '8px',
+              minWidth: 'max-content',
+              borderRadius: '50%',
+              cursor: 'pointer',
+            }}
+          >
+            <Add size='XS' />
+          </Button>
+          <Tooltip>
+            <Text>Start a new live activity</Text>
+          </Tooltip>
+        </TooltipTrigger>
+      ) : (
+        // Full mode: Button with icon and text
+        <Button 
+          variant="cta" 
+          isDisabled={isButtonDisabled}
+          aria-label={buttonTooltip}
+        >
+          <Rocket />
+          <Text>{formatMessage(liveActivityMessages.launchLiveActivity)}</Text>
+        </Button>
+      )}
       
       {(close) => (
         <Dialog>

--- a/packages/ui-plugins/live-activities/src/components/live-activity/update-activity.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/update-activity.tsx
@@ -29,7 +29,10 @@ import {
   generateLiveActivityPayload,
   sendLiveActivityNotification,
   generateUpdateTemplate,
-  buildCompleteApsPayload
+  buildCompleteApsPayload,
+  ACTIVITY_TYPE,
+  ActivityType,
+  EVENT_TYPE
 } from '../../api/liveActivityApi';
 import { LiveActivity } from '../../hooks/useActivities';
 import { LIVE_ACTIVITY_DEFAULTS, MESSAGES as COMMON_MESSAGES } from '../../constants/liveActivitiesConfig';
@@ -57,8 +60,8 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
   const { formatMessage } = useIntl();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [eventType, setEventType] = useState<'update' | 'end'>('update');
-  const [activityTypeSelection, setActivityTypeSelection] = useState<'unitary' | 'broadcast'>(activity.type || 'unitary');
+  const [eventType, setEventType] = useState<typeof EVENT_TYPE.UPDATE | typeof EVENT_TYPE.END>(EVENT_TYPE.UPDATE);
+  const [activityTypeSelection, setActivityTypeSelection] = useState<ActivityType>(activity.type || ACTIVITY_TYPE.UNITARY);
   const [broadcastChannelId, setBroadcastChannelId] = useState<string>(activity.broadcastChannelId || '');
 
   // Context (doesn't require push token for update operations)
@@ -80,7 +83,7 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
       reset({
         payload: JSON.stringify(generateUpdateTemplate(activity), null, 2)
       });
-      setActivityTypeSelection(activity.type || 'unitary');
+      setActivityTypeSelection(activity.type || ACTIVITY_TYPE.UNITARY);
       setBroadcastChannelId(activity.broadcastChannelId || '');
     }
   }, [activity?.id, activity?.broadcastChannelId, activity?.currentContentState, activity?.type, reset]);
@@ -101,12 +104,12 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
 
       // Validate update token exists for unitary activities
       // Broadcast activities don't require an update token
-      if (activityTypeSelection === 'unitary' && !activity.updateToken) {
+      if (activityTypeSelection === ACTIVITY_TYPE.UNITARY && !activity.updateToken) {
         throw new Error('Update token not available for this activity');
       }
 
       // Validate broadcast channel ID if broadcast type is selected
-      if (activityTypeSelection === 'broadcast' && !broadcastChannelId.trim()) {
+      if (activityTypeSelection === ACTIVITY_TYPE.BROADCAST && !broadcastChannelId.trim()) {
         throw new Error(formatMessage(liveActivityMessages.broadcastChannelIdRequired));
       }
 
@@ -115,13 +118,13 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
         userPayload,
         eventType,
         attributesType: activity.attributes || 'unknown',
-        broadcastChannelId: activityTypeSelection === 'broadcast' ? broadcastChannelId : undefined
+        broadcastChannelId: activityTypeSelection === ACTIVITY_TYPE.BROADCAST ? broadcastChannelId : undefined
       });
 
       // Generate complete payload
       // For unitary: use updateToken
       // For broadcast: use pushToStartToken or empty string (token not required for broadcast updates)
-      const token = activityTypeSelection === 'unitary' 
+      const token = activityTypeSelection === ACTIVITY_TYPE.UNITARY 
         ? activity.updateToken 
         : (activity.pushToStartToken || '');
 
@@ -136,7 +139,7 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
         sandboxName: context.sandbox?.name || LIVE_ACTIVITY_DEFAULTS.SANDBOX,
         environment: context.environment,
         type: activityTypeSelection,
-        broadcastChannelId: activityTypeSelection === 'broadcast' ? broadcastChannelId : undefined
+        broadcastChannelId: activityTypeSelection === ACTIVITY_TYPE.BROADCAST ? broadcastChannelId : undefined
       });
 
       // Make API call
@@ -158,8 +161,8 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
 
   const handleReset = useCallback(() => {
     reset();
-    setEventType('update');
-    setActivityTypeSelection(activity.type || 'unitary');
+    setEventType(EVENT_TYPE.UPDATE);
+    setActivityTypeSelection(activity.type || ACTIVITY_TYPE.UNITARY);
     setBroadcastChannelId(activity.broadcastChannelId || '');
     setError(null);
   }, [reset, activity.type, activity.broadcastChannelId]);
@@ -167,7 +170,7 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
   // Computed values
   // For unitary activities: require update token
   // For broadcast activities: update token is not required
-  const requiresToken = activityTypeSelection === 'unitary' && !activity.updateToken;
+  const requiresToken = activityTypeSelection === ACTIVITY_TYPE.UNITARY && !activity.updateToken;
   // Only disable for unitary completed activities (broadcast channels can be reused)
   // const isButtonDisabled = !context.isReady || isLoading || requiresToken || 
   //   (activityTypeSelection === 'unitary' && activity.status === 'completed');
@@ -203,11 +206,11 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
               <RadioGroup 
                 label={formatMessage(liveActivityMessages.eventType)}
                 value={eventType}
-                onChange={(value) => setEventType(value as 'update' | 'end')}
+                onChange={(value) => setEventType(value as typeof EVENT_TYPE.UPDATE | typeof EVENT_TYPE.END)}
                 orientation="horizontal"
               >
-                <Radio value="update">{formatMessage(liveActivityMessages.eventTypeUpdate)}</Radio>
-                <Radio value="end">{formatMessage(liveActivityMessages.eventTypeEnd)}</Radio>
+                <Radio value={EVENT_TYPE.UPDATE}>{formatMessage(liveActivityMessages.eventTypeUpdate)}</Radio>
+                <Radio value={EVENT_TYPE.END}>{formatMessage(liveActivityMessages.eventTypeEnd)}</Radio>
               </RadioGroup>
             </View>
 
@@ -215,16 +218,16 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
               <RadioGroup 
                 label={formatMessage(liveActivityMessages.activityType)}
                 value={activityTypeSelection}
-                onChange={(value) => setActivityTypeSelection(value as 'unitary' | 'broadcast')}
+                onChange={(value) => setActivityTypeSelection(value as ActivityType)}
                 orientation="horizontal"
                 isDisabled
               >
-                <Radio value="unitary">{formatMessage(liveActivityMessages.activityTypeUnitary)}</Radio>
-                <Radio value="broadcast">{formatMessage(liveActivityMessages.activityTypeBroadcast)}</Radio>
+                <Radio value={ACTIVITY_TYPE.UNITARY}>{formatMessage(liveActivityMessages.activityTypeUnitary)}</Radio>
+                <Radio value={ACTIVITY_TYPE.BROADCAST}>{formatMessage(liveActivityMessages.activityTypeBroadcast)}</Radio>
               </RadioGroup>
             </View>
 
-            {activityTypeSelection === 'broadcast' && (
+            {activityTypeSelection === ACTIVITY_TYPE.BROADCAST && (
               <View marginBottom="size-200">
                 <TextField
                   label={formatMessage(liveActivityMessages.broadcastChannelId)}

--- a/packages/ui-plugins/live-activities/src/components/live-activity/update-activity.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/update-activity.tsx
@@ -29,13 +29,16 @@ import {
   generateLiveActivityPayload,
   sendLiveActivityNotification,
   generateUpdateTemplate,
-  buildCompleteApsPayload,
+  buildCompleteApsPayload
+} from '../../api/liveActivityApi';
+import { LiveActivity } from '../../hooks/useActivities';
+import { 
+  LIVE_ACTIVITY_DEFAULTS, 
+  MESSAGES as COMMON_MESSAGES,
   ACTIVITY_TYPE,
   ActivityType,
   EVENT_TYPE
-} from '../../api/liveActivityApi';
-import { LiveActivity } from '../../hooks/useActivities';
-import { LIVE_ACTIVITY_DEFAULTS, MESSAGES as COMMON_MESSAGES } from '../../constants/liveActivitiesConfig';
+} from '../../constants/liveActivitiesConfig';
 import { ErrorMessage, JsonEditor, DialogActions } from './common';
 import { useLiveActivityContext } from '../../hooks/useLiveActivityContext';
 import { liveActivityMessages, actionMessages } from '../../i18n';
@@ -86,7 +89,7 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
       setActivityTypeSelection(activity.type || ACTIVITY_TYPE.UNITARY);
       setBroadcastChannelId(activity.broadcastChannelId || '');
     }
-  }, [activity?.id, activity?.broadcastChannelId, activity?.currentContentState, activity?.type, reset]);
+  }, [activity?.id, activity?.broadcastChannelId, activity?.currentContentState, activity?.type]);
 
   // Handlers
   const handleUpdate = useCallback(async (data: FormValues) => {
@@ -113,12 +116,15 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
         throw new Error(formatMessage(liveActivityMessages.broadcastChannelIdRequired));
       }
 
+      // Determine broadcast channel ID based on activity type
+      const channelIdToSend = activityTypeSelection === ACTIVITY_TYPE.BROADCAST ? broadcastChannelId : undefined;
+
       // Build complete APS payload by merging user input with auto-generated fields
       const completeApsPayload = buildCompleteApsPayload({
         userPayload,
         eventType,
         attributesType: activity.attributes || 'unknown',
-        broadcastChannelId: activityTypeSelection === ACTIVITY_TYPE.BROADCAST ? broadcastChannelId : undefined
+        broadcastChannelId: channelIdToSend
       });
 
       // Generate complete payload
@@ -132,14 +138,14 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
         apsContent: completeApsPayload,
         appId: context.appId!,
         platform: context.platform,
-        token: token!,
+        token: token, // marked as optional in the type definition for broadcast activities
         ecid: context.ecid!,
         imsOrg: context.imsOrg!,
         sessionId: context.sessionId!,
         sandboxName: context.sandbox?.name || LIVE_ACTIVITY_DEFAULTS.SANDBOX,
         environment: context.environment,
         type: activityTypeSelection,
-        broadcastChannelId: activityTypeSelection === ACTIVITY_TYPE.BROADCAST ? broadcastChannelId : undefined
+        broadcastChannelId: channelIdToSend
       });
 
       // Make API call
@@ -157,7 +163,7 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
     } finally {
       setIsLoading(false);
     }
-  }, [activity, context, eventType, activityTypeSelection, broadcastChannelId, formatMessage]);
+  }, [activity, context, eventType, activityTypeSelection, broadcastChannelId]);
 
   const handleReset = useCallback(() => {
     reset();
@@ -165,17 +171,10 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
     setActivityTypeSelection(activity.type || ACTIVITY_TYPE.UNITARY);
     setBroadcastChannelId(activity.broadcastChannelId || '');
     setError(null);
-  }, [reset, activity.type, activity.broadcastChannelId]);
+  }, [activity.type, activity.broadcastChannelId]);
 
-  // Computed values
-  // For unitary activities: require update token
-  // For broadcast activities: update token is not required
+  // For unitary activities: require update token. For broadcast: token is not required.
   const requiresToken = activityTypeSelection === ACTIVITY_TYPE.UNITARY && !activity.updateToken;
-  // Only disable for unitary completed activities (broadcast channels can be reused)
-  // const isButtonDisabled = !context.isReady || isLoading || requiresToken || 
-  //   (activityTypeSelection === 'unitary' && activity.status === 'completed');
-
-  // Disable if not ready or loading or requires token (Enabling for other cases)
   const isButtonDisabled = !context.isReady || isLoading || requiresToken;
 
   return (

--- a/packages/ui-plugins/live-activities/src/components/live-activity/update-activity.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/update-activity.tsx
@@ -121,8 +121,6 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
       // Generate complete payload
       // For unitary: use updateToken
       // For broadcast: use pushToStartToken or empty string (token not required for broadcast updates)
-      // TODO: REVIEW - VERIFY IF BROADCAST UPDATES ACTUALLY NEED A TOKEN AND WHICH TOKEN TO USE
-      // TODO: REVIEW - WHAT SHOULD HAPPEN IF pushToStartToken IS MISSING? EMPTY STRING OR ERROR?
       const token = activityTypeSelection === 'unitary' 
         ? activity.updateToken 
         : (activity.pushToStartToken || '');
@@ -171,8 +169,11 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
   // For broadcast activities: update token is not required
   const requiresToken = activityTypeSelection === 'unitary' && !activity.updateToken;
   // Only disable for unitary completed activities (broadcast channels can be reused)
-  const isButtonDisabled = !context.isReady || isLoading || requiresToken || 
-    (activityTypeSelection === 'unitary' && activity.status === 'completed');
+  // const isButtonDisabled = !context.isReady || isLoading || requiresToken || 
+  //   (activityTypeSelection === 'unitary' && activity.status === 'completed');
+
+  // Disable if not ready or loading or requires token (Enabling for other cases)
+  const isButtonDisabled = !context.isReady || isLoading || requiresToken;
 
   return (
     <DialogTrigger>

--- a/packages/ui-plugins/live-activities/src/components/live-activity/update-activity.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/update-activity.tsx
@@ -121,6 +121,8 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
       // Generate complete payload
       // For unitary: use updateToken
       // For broadcast: use pushToStartToken or empty string (token not required for broadcast updates)
+      // TODO: REVIEW - VERIFY IF BROADCAST UPDATES ACTUALLY NEED A TOKEN AND WHICH TOKEN TO USE
+      // TODO: REVIEW - WHAT SHOULD HAPPEN IF pushToStartToken IS MISSING? EMPTY STRING OR ERROR?
       const token = activityTypeSelection === 'unitary' 
         ? activity.updateToken 
         : (activity.pushToStartToken || '');
@@ -184,7 +186,7 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
         <Dialog>
           <Heading>
             {formatMessage(liveActivityMessages.updateLiveActivityHeading, { 
-              activityId: activity.id || activity.name
+              activityId: activity.id || activity.broadcastChannelId || activity.name
             })}
           </Heading>
           <Divider />

--- a/packages/ui-plugins/live-activities/src/components/live-activity/update-activity.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/update-activity.tsx
@@ -17,7 +17,8 @@ import {
   Text,
   RadioGroup,
   Radio,
-  ToastQueue
+  ToastQueue,
+  TextField
 } from '@adobe/react-spectrum';
 import { useIntl } from 'react-intl';
 import Send from '@spectrum-icons/workflow/Send';
@@ -57,6 +58,8 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [eventType, setEventType] = useState<'update' | 'end'>('update');
+  const [activityTypeSelection, setActivityTypeSelection] = useState<'unitary' | 'broadcast'>(activity.type || 'unitary');
+  const [broadcastChannelId, setBroadcastChannelId] = useState<string>(activity.broadcastChannelId || '');
 
   // Context (doesn't require push token for update operations)
   const context = useLiveActivityContext({ requirePushToken: false });
@@ -73,12 +76,14 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
   });
 
   useEffect(() => {
-    if (activity?.id) {
+    if (activity?.id || activity?.broadcastChannelId) {
       reset({
         payload: JSON.stringify(generateUpdateTemplate(activity), null, 2)
       });
+      setActivityTypeSelection(activity.type || 'unitary');
+      setBroadcastChannelId(activity.broadcastChannelId || '');
     }
-  }, [activity?.id, activity?.currentContentState, reset]);
+  }, [activity?.id, activity?.broadcastChannelId, activity?.currentContentState, activity?.type, reset]);
 
   // Handlers
   const handleUpdate = useCallback(async (data: FormValues) => {
@@ -94,9 +99,15 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
         throw new Error('Invalid JSON format in payload');
       }
 
-      // Validate update token exists
-      if (!activity.updateToken) {
+      // Validate update token exists for unitary activities
+      // Broadcast activities don't require an update token
+      if (activityTypeSelection === 'unitary' && !activity.updateToken) {
         throw new Error('Update token not available for this activity');
+      }
+
+      // Validate broadcast channel ID if broadcast type is selected
+      if (activityTypeSelection === 'broadcast' && !broadcastChannelId.trim()) {
+        throw new Error(formatMessage(liveActivityMessages.broadcastChannelIdRequired));
       }
 
       // Build complete APS payload by merging user input with auto-generated fields
@@ -104,19 +115,28 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
         userPayload,
         eventType,
         attributesType: activity.attributes || 'unknown',
+        broadcastChannelId: activityTypeSelection === 'broadcast' ? broadcastChannelId : undefined
       });
 
-      // Generate complete payload using update token
+      // Generate complete payload
+      // For unitary: use updateToken
+      // For broadcast: use pushToStartToken or empty string (token not required for broadcast updates)
+      const token = activityTypeSelection === 'unitary' 
+        ? activity.updateToken 
+        : (activity.pushToStartToken || '');
+
       const payload = generateLiveActivityPayload({
         apsContent: completeApsPayload,
         appId: context.appId!,
         platform: context.platform,
-        token: activity.updateToken, // Using updateToken for updates
+        token: token!,
         ecid: context.ecid!,
         imsOrg: context.imsOrg!,
         sessionId: context.sessionId!,
         sandboxName: context.sandbox?.name || LIVE_ACTIVITY_DEFAULTS.SANDBOX,
-        environment: context.environment
+        environment: context.environment,
+        type: activityTypeSelection,
+        broadcastChannelId: activityTypeSelection === 'broadcast' ? broadcastChannelId : undefined
       });
 
       // Make API call
@@ -134,16 +154,21 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
     } finally {
       setIsLoading(false);
     }
-  }, [activity, context, eventType]);
+  }, [activity, context, eventType, activityTypeSelection, broadcastChannelId, formatMessage]);
 
   const handleReset = useCallback(() => {
     reset();
     setEventType('update');
+    setActivityTypeSelection(activity.type || 'unitary');
+    setBroadcastChannelId(activity.broadcastChannelId || '');
     setError(null);
-  }, [reset]);
+  }, [reset, activity.type, activity.broadcastChannelId]);
 
   // Computed values
-  const isButtonDisabled = !context.isReady || isLoading || !activity.updateToken || activity.status === 'completed';
+  // For unitary activities: require update token
+  // For broadcast activities: update token is not required
+  const requiresToken = activityTypeSelection === 'unitary' && !activity.updateToken;
+  const isButtonDisabled = !context.isReady || isLoading || requiresToken || activity.status === 'completed';
 
   return (
     <DialogTrigger>
@@ -180,6 +205,34 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
                 <Radio value="end">{formatMessage(liveActivityMessages.eventTypeEnd)}</Radio>
               </RadioGroup>
             </View>
+
+            <View marginBottom="size-200">
+              <RadioGroup 
+                label={formatMessage(liveActivityMessages.activityType)}
+                value={activityTypeSelection}
+                onChange={(value) => setActivityTypeSelection(value as 'unitary' | 'broadcast')}
+                orientation="horizontal"
+                isDisabled
+              >
+                <Radio value="unitary">{formatMessage(liveActivityMessages.activityTypeUnitary)}</Radio>
+                <Radio value="broadcast">{formatMessage(liveActivityMessages.activityTypeBroadcast)}</Radio>
+              </RadioGroup>
+            </View>
+
+            {activityTypeSelection === 'broadcast' && (
+              <View marginBottom="size-200">
+                <TextField
+                  label={formatMessage(liveActivityMessages.broadcastChannelId)}
+                  placeholder={formatMessage(liveActivityMessages.broadcastChannelIdPlaceholder)}
+                  value={broadcastChannelId}
+                  onChange={setBroadcastChannelId}
+                  width="100%"
+                  isRequired
+                  isDisabled
+                  isReadOnly
+                />
+              </View>
+            )}
 
             <Controller
               name="payload"

--- a/packages/ui-plugins/live-activities/src/components/live-activity/update-activity.tsx
+++ b/packages/ui-plugins/live-activities/src/components/live-activity/update-activity.tsx
@@ -170,7 +170,9 @@ function UpdateActivity({ activity }: Readonly<UpdateActivityProps>) {
   // For unitary activities: require update token
   // For broadcast activities: update token is not required
   const requiresToken = activityTypeSelection === 'unitary' && !activity.updateToken;
-  const isButtonDisabled = !context.isReady || isLoading || requiresToken || activity.status === 'completed';
+  // Only disable for unitary completed activities (broadcast channels can be reused)
+  const isButtonDisabled = !context.isReady || isLoading || requiresToken || 
+    (activityTypeSelection === 'unitary' && activity.status === 'completed');
 
   return (
     <DialogTrigger>

--- a/packages/ui-plugins/live-activities/src/constants/liveActivitiesConfig.ts
+++ b/packages/ui-plugins/live-activities/src/constants/liveActivitiesConfig.ts
@@ -1,5 +1,24 @@
 import { defineMessages } from 'react-intl';
 
+// Live Activity Types
+export const ACTIVITY_TYPE = {
+  UNITARY: 'unitary',
+  BROADCAST: 'broadcast',
+  UNKNOWN: 'unknown'
+} as const;
+
+export type ActivityType = typeof ACTIVITY_TYPE[keyof typeof ACTIVITY_TYPE];
+
+// Live Activity Event Types
+export const EVENT_TYPE = {
+  START: 'start',
+  UPDATE: 'update',
+  END: 'end',
+  REMOTE_START: 'remotestart'
+} as const;
+
+export type EventType = typeof EVENT_TYPE[keyof typeof EVENT_TYPE];
+
 // UI Configuration
 export const UI_CONFIG = {
   MAX_COPY_LENGTH: 50,

--- a/packages/ui-plugins/live-activities/src/constants/matchers.ts
+++ b/packages/ui-plugins/live-activities/src/constants/matchers.ts
@@ -29,6 +29,8 @@ export const LIVE_ACTIVITIES_MATCHERS = {
     'payload.ACPExtensionEventData.liveActivityID',
     'payload.ACPExtensionEventData.data.liveActivityID',
     'payload.ACPExtensionEventData.activityId',
+    'payload.ACPExtensionEventData.channelID',
+    'payload.ACPExtensionEventData.data.channelID',
     'payload.ACPExtensionEventData.isLiveActivityPushToStartTokenEvent',
     'payload.ACPExtensionEventData.isLiveActivityUpdateTokenEvent',
     'payload.ACPExtensionEventData.isLiveActivityTrackStartEvent',
@@ -43,7 +45,9 @@ export const LIVE_ACTIVITIES_MATCHERS = {
     'payload.ACPExtensionEventName==`Live Activity ended`',
     'payload.ACPExtensionEventData.liveActivityID',
     'payload.ACPExtensionEventData.data.liveActivityID',
-    'payload.ACPExtensionEventData.activityId'
+    'payload.ACPExtensionEventData.activityId',
+    'payload.ACPExtensionEventData.channelID',
+    'payload.ACPExtensionEventData.data.channelID',
   ]),
 
   TOKEN_EVENTS: combineAny([

--- a/packages/ui-plugins/live-activities/src/containers/activities.tsx
+++ b/packages/ui-plugins/live-activities/src/containers/activities.tsx
@@ -14,7 +14,7 @@ import './activities.css';
 
 import { VALIDATION_STATUS } from '../constants';
 import { NAVIGATION_CONFIG } from '../constants/liveActivitiesConfig';
-import useActivities, { useRegisteredActivities } from '../hooks/useActivities';
+import useActivities, { useRegisteredActivities, getActivityKey } from '../hooks/useActivities';
 import { useLiveActivitiesValidationStatus } from '../hooks/useLiveActivitiesValidationStatus';
 import type { ActivityTab } from '../hooks/usePluginState';
 import usePluginState from '../hooks/usePluginState';
@@ -73,7 +73,7 @@ function Activities() {
   const selectedActivityTabs = useMemo(() => {
     if (!selectedActivityId) return null;
     
-    const selectedActivity = activities.find(a => a.id === selectedActivityId);
+    const selectedActivity = activities.find(a => getActivityKey(a) === selectedActivityId);
     return (
       <Tabs
         height="100%"

--- a/packages/ui-plugins/live-activities/src/containers/activities.tsx
+++ b/packages/ui-plugins/live-activities/src/containers/activities.tsx
@@ -172,10 +172,12 @@ function Activities() {
           UNSAFE_style={{ 
             border: 'none',
             outline: 'none',
-            boxShadow: 'none'
+            boxShadow: 'none',
+            padding: '4px',
+            minWidth: 'max-content',
           }}
         >
-          <Info />
+          <Info size='S'/>
         </Button>
         <Tooltip>
           <Text>{getTooltipMessage()}</Text>
@@ -184,22 +186,20 @@ function Activities() {
     );
   };
 
+  // Action button component for ActivityList (compact mode)
+  const ActionButton = () => {
+    if (!platform.hasLiveActivities) return null;
+    return (
+      <>
+        {platform.hasRemoteStart && <LaunchLiveActivity compact />}
+        {!platform.hasRemoteStart && <InfoButton />}
+      </>
+    );
+  };
+
   return (
     <View height="100vh" overflow="hidden">
       <Flex direction="column" height="100%">
-        {/* Header with Launch Button - Only show when there are activities */}
-        {activities.length > 0 && (
-          <View borderBottomWidth="thin" borderBottomColor="gray-300" padding="size-200">
-            <Flex direction="row" justifyContent="end" alignItems="center">              
-              {platform.hasLiveActivities && (
-                <Flex alignItems="center" gap="size-100">
-                  {platform.hasRemoteStart && <LaunchLiveActivity />}
-                  <InfoButton />
-                </Flex>
-              )}
-            </Flex>
-          </View>
-        )}
 
         {/* No Activities State */}
         {!activities.length && (
@@ -247,6 +247,7 @@ function Activities() {
                 selectedActivityId={selectedActivityId ?? undefined}
                 onActivitySelect={handleActivitySelect}
                 isLoading={false}
+                actionButton={<ActionButton />}
               />
             </View>
 

--- a/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
@@ -70,7 +70,7 @@ export function getActivityKey(activity: LiveActivity): string {
     return `unitary:${activity.id}`;
   }
   // Fallback (shouldn't happen in normal cases)
-  return `unknown:${activity.name}:${activity.startTime || Date.now()}`;
+  return `unknown:${activity.name}:${activity.startTime || 'no-timestamp'}`;
 }
 
 /**
@@ -90,13 +90,12 @@ function extractActivityMetadata(event: any): {
     return null;
   }
 
-  // Detect activity type - check explicit type field first, then fallback to channelID presence
-  const explicitType = eventData.type;
+  // Detect activity type based on channelID presence
+  // If channelID exists, it's a broadcast activity; otherwise it's unitary
   const channelId = eventData.channelID || eventData.data?.channelID;
   const liveActivityId = eventData.liveActivityID || eventData.data?.liveActivityID || eventData.activityId;
   
-  const activityType: 'unitary' | 'broadcast' = 
-    explicitType === 'broadcast' || (channelId && !explicitType) ? 'broadcast' : 'unitary';
+  const activityType: 'unitary' | 'broadcast' = channelId ? 'broadcast' : 'unitary';
   
   // Determine grouping key based on activity type
   // For broadcast: group by channelID (required)

--- a/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
@@ -2,7 +2,7 @@ import { useEvents } from '@assurance/plugin-bridge-provider';
 
 import { useMemo } from 'react';
 
-import { ACTIVITY_TYPE, ActivityType } from '../api/liveActivityApi';
+import { ACTIVITY_TYPE, ActivityType } from '../constants/liveActivitiesConfig';
 import { LIVE_ACTIVITIES_MATCHERS } from '../constants/matchers';
 import {
   isLiveActivityDismissedEvent,
@@ -54,10 +54,12 @@ export interface LiveActivity {
  * For unitary activities: uses the activity ID
  * For broadcast activities: uses the channel ID + attribute type (to support multiple activity types per channel)
  * 
- * @param activity - The live activity
- * @returns A unique string key for the activity
+ * @param activity - The live activity (can be undefined)
+ * @returns A unique string key for the activity, or empty string if activity is not provided
  */
-export function getActivityKey(activity: LiveActivity): string {
+export function getActivityKey(activity: LiveActivity | undefined): string {
+  if (!activity) return '';
+  
   // For broadcast: use channelId + attributeType as the key (supports multiple types per channel)
   if (activity.type === ACTIVITY_TYPE.BROADCAST && activity.broadcastChannelId) {
     return `${ACTIVITY_TYPE.BROADCAST}:${activity.broadcastChannelId}:${activity.name}`;
@@ -97,7 +99,7 @@ export function isUnitaryActivityKey(activityKey: string): boolean {
  * @returns Object containing the parsed components: type, channelId, attributeType, and liveActivityId
  */
 export function parseActivityKey(activityKey: string): {
-  type: 'broadcast' | 'unitary' | 'unknown';
+  type: ActivityType;
   channelId?: string;
   attributeType?: string;
   liveActivityId?: string;
@@ -106,7 +108,7 @@ export function parseActivityKey(activityKey: string): {
     // Format: "broadcast:channelId:attributeType"
     const parts = activityKey.split(':');
     return {
-      type: 'broadcast',
+      type: ACTIVITY_TYPE.BROADCAST,
       channelId: parts[1],
       attributeType: parts[2]
     };
@@ -116,14 +118,14 @@ export function parseActivityKey(activityKey: string): {
     // Format: "unitary:liveActivityId"
     const parts = activityKey.split(':');
     return {
-      type: 'unitary',
+      type: ACTIVITY_TYPE.UNITARY,
       liveActivityId: parts[1]
     };
   }
   
   // Unknown format (fallback for backward compatibility)
   return {
-    type: 'unknown',
+    type: ACTIVITY_TYPE.UNKNOWN,
     liveActivityId: activityKey
   };
 }

--- a/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
@@ -1,8 +1,4 @@
-import { combineAny } from '@adobe/griffon-toolkit';
-
 import { useEvents } from '@assurance/plugin-bridge-provider';
-
-import groupBy from 'lodash/groupBy';
 
 import { useMemo } from 'react';
 

--- a/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
@@ -180,10 +180,18 @@ function extractActiveActivitiesFromEvents(events: any[]): any[] {
     if (!activity.channelId && channelId) {
       activity.channelId = channelId;
     }
+  });
 
-    // Only update status to completed if this is an end event (dismissed or ended)
-    if (isLiveActivityEndEvent(event)) {
-      activity.status = 'completed';
+  // Determine status based on the latest lifecycle event (for broadcast channel reuse)
+  activitiesMap.forEach(activity => {
+    const lifecycleEvents = activity.events.filter(e => 
+      isLiveActivityStartEvent(e) || isLiveActivityEndEvent(e)
+    );
+    
+    if (lifecycleEvents.length > 0) {
+      // Sort by timestamp descending and get the latest
+      const latestEvent = lifecycleEvents.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))[0];
+      activity.status = isLiveActivityEndEvent(latestEvent) ? 'completed' : 'active';
     }
   });
 

--- a/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
@@ -48,6 +48,8 @@ export interface LiveActivity {
   examplePayload?: any;
   schema?: any;
   currentContentState?: any;
+  type?: 'unitary' | 'broadcast';
+  broadcastChannelId?: string;
 }
 
 /**
@@ -62,8 +64,10 @@ function extractActivityMetadata(event: any): { activityId: string; attributeTyp
   }
 
   // Use the same flexible matching logic as useActivityEvents
-  const activityId =
-    eventData.liveActivityID || eventData.data?.liveActivityID || eventData.activityId;
+  const activityType = eventData.channelID ? 'broadcast' : 'unitary';
+  const activityId = activityType === 'broadcast' 
+    ? (eventData.channelID || eventData.data?.channelID)
+    : (eventData.liveActivityID || eventData.data?.liveActivityID || eventData.activityId);
 
   // For attributeType, try multiple possible locations
   const attributeType =
@@ -142,6 +146,7 @@ function useActivities(): LiveActivity[] {
     sorted: 'desc'
   });
 
+  console.log(allEvents, 'allEvents (((((');
   // Use type guard-based extraction functions
   const activeActivities = extractActiveActivitiesFromEvents(allEvents);
   const schemaData = extractSchemaDataFromEvents(allEvents);
@@ -157,6 +162,8 @@ function useActivities(): LiveActivity[] {
       pushToStartTokenMap.set(attributeType, event);
     }
   });
+
+  console.log(activeActivities, 'activeActivities');
 
   // Create activities from the extracted active activities
   return activeActivities.map(activity => {
@@ -178,6 +185,11 @@ function useActivities(): LiveActivity[] {
     // Get schema data for this attribute type
     const schemaDataForType = schemaData.get(attributeType);
 
+    // Extract type and broadcastChannelId from start event
+    const broadcastChannelId = startEvent?.payload?.ACPExtensionEventData?.channelID;
+    const activityType = broadcastChannelId ? 'broadcast' : 'unitary';
+
+
     return {
       id,
       name: attributeType, // Use attributeType as name for backward compatibility
@@ -193,7 +205,9 @@ function useActivities(): LiveActivity[] {
       pushToStartToken: pushToStartTokenEvent?.payload?.ACPExtensionEventData?.token,
       updateToken: updateTokenEvent?.payload?.ACPExtensionEventData?.token,
       updateEvents,
-      currentContentState
+      currentContentState,
+      type: activityType as 'unitary' | 'broadcast',
+      broadcastChannelId
     };
   });
 }

--- a/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
@@ -71,6 +71,64 @@ export function getActivityKey(activity: LiveActivity): string {
 }
 
 /**
+ * Checks if an activity key represents a broadcast activity.
+ * 
+ * @param activityKey - The activity key to check
+ * @returns True if the key represents a broadcast activity
+ */
+export function isBroadcastActivityKey(activityKey: string): boolean {
+  return activityKey.startsWith(`${ACTIVITY_TYPE.BROADCAST}:`);
+}
+
+/**
+ * Checks if an activity key represents a unitary activity.
+ * 
+ * @param activityKey - The activity key to check
+ * @returns True if the key represents a unitary activity
+ */
+export function isUnitaryActivityKey(activityKey: string): boolean {
+  return activityKey.startsWith(`${ACTIVITY_TYPE.UNITARY}:`);
+}
+
+/**
+ * Parses an activity key to extract its components.
+ * 
+ * @param activityKey - The activity key to parse
+ * @returns Object containing the parsed components: type, channelId, attributeType, and liveActivityId
+ */
+export function parseActivityKey(activityKey: string): {
+  type: 'broadcast' | 'unitary' | 'unknown';
+  channelId?: string;
+  attributeType?: string;
+  liveActivityId?: string;
+} {
+  if (isBroadcastActivityKey(activityKey)) {
+    // Format: "broadcast:channelId:attributeType"
+    const parts = activityKey.split(':');
+    return {
+      type: 'broadcast',
+      channelId: parts[1],
+      attributeType: parts[2]
+    };
+  }
+  
+  if (isUnitaryActivityKey(activityKey)) {
+    // Format: "unitary:liveActivityId"
+    const parts = activityKey.split(':');
+    return {
+      type: 'unitary',
+      liveActivityId: parts[1]
+    };
+  }
+  
+  // Unknown format (fallback for backward compatibility)
+  return {
+    type: 'unknown',
+    liveActivityId: activityKey
+  };
+}
+
+/**
  * Extracts activity metadata from Live Activity events.
  * @param event - The event to extract metadata from
  * @returns Object with grouping key, IDs, type, and attributeType, or null if not found

--- a/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
@@ -205,7 +205,6 @@ function useActivities(): LiveActivity[] {
     sorted: 'desc'
   });
 
-  console.log(allEvents, 'allEvents (((((');
   // Use type guard-based extraction functions
   const activeActivities = extractActiveActivitiesFromEvents(allEvents);
   const schemaData = extractSchemaDataFromEvents(allEvents);

--- a/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
@@ -53,31 +53,71 @@ export interface LiveActivity {
 }
 
 /**
+ * Gets a unique key for a live activity that works for both unitary and broadcast types.
+ * For unitary activities: uses the activity ID
+ * For broadcast activities: uses the channel ID
+ * 
+ * @param activity - The live activity
+ * @returns A unique string key for the activity
+ */
+export function getActivityKey(activity: LiveActivity): string {
+  // For broadcast: use channelId as the key
+  if (activity.type === 'broadcast' && activity.broadcastChannelId) {
+    return `broadcast:${activity.broadcastChannelId}`;
+  }
+  // For unitary: use id as the key
+  if (activity.id) {
+    return `unitary:${activity.id}`;
+  }
+  // Fallback (shouldn't happen in normal cases)
+  return `unknown:${activity.name}:${activity.startTime || Date.now()}`;
+}
+
+/**
  * Extracts activity metadata from Live Activity events.
  * @param event - The event to extract metadata from
- * @returns Object with activityId and attributeType, or null if not found
+ * @returns Object with grouping key, IDs, type, and attributeType, or null if not found
  */
-function extractActivityMetadata(event: any): { activityId: string; attributeType: string } | null {
+function extractActivityMetadata(event: any): { 
+  groupingKey: string;
+  liveActivityId?: string;
+  channelId?: string;
+  attributeType: string;
+  activityType: 'unitary' | 'broadcast';
+} | null {
   const eventData = event.payload?.ACPExtensionEventData;
   if (!eventData) {
     return null;
   }
 
-  // Use the same flexible matching logic as useActivityEvents
-  const activityType = eventData.channelID ? 'broadcast' : 'unitary';
-  const activityId = activityType === 'broadcast' 
-    ? (eventData.channelID || eventData.data?.channelID)
-    : (eventData.liveActivityID || eventData.data?.liveActivityID || eventData.activityId);
-
+  // Detect activity type - check explicit type field first, then fallback to channelID presence
+  const explicitType = eventData.type;
+  const channelId = eventData.channelID || eventData.data?.channelID;
+  const liveActivityId = eventData.liveActivityID || eventData.data?.liveActivityID || eventData.activityId;
+  
+  const activityType: 'unitary' | 'broadcast' = 
+    explicitType === 'broadcast' || (channelId && !explicitType) ? 'broadcast' : 'unitary';
+  
+  // Determine grouping key based on activity type
+  // For broadcast: group by channelID (required)
+  // For unitary: group by liveActivityID (required)
+  const groupingKey = activityType === 'broadcast' ? channelId : liveActivityId;
+  
   // For attributeType, try multiple possible locations
   const attributeType =
-    eventData.attributeType || eventData.data?.attributeType || eventData.type || 'unknown'; // Fallback for events without attributeType
+    eventData.attributeType || eventData.data?.attributeType || 'unknown';
 
-  if (!activityId) {
+  if (!groupingKey) {
     return null;
   }
 
-  return { activityId, attributeType };
+  return { 
+    groupingKey,
+    liveActivityId,
+    channelId,
+    attributeType,
+    activityType
+  };
 }
 
 /**
@@ -106,12 +146,14 @@ function extractActiveActivitiesFromEvents(events: any[]): any[] {
     const metadata = extractActivityMetadata(event);
     if (!metadata) return;
 
-    const { activityId, attributeType } = metadata;
+    const { groupingKey, liveActivityId, channelId, attributeType, activityType } = metadata;
 
     // Initialize activity if not exists
-    if (!activitiesMap.has(activityId)) {
-      activitiesMap.set(activityId, {
-        id: activityId,
+    if (!activitiesMap.has(groupingKey)) {
+      activitiesMap.set(groupingKey, {
+        liveActivityId: liveActivityId,
+        channelId: channelId,
+        activityType: activityType,
         attributeType,
         events: [],
         status: 'active'
@@ -119,7 +161,7 @@ function extractActiveActivitiesFromEvents(events: any[]): any[] {
     }
 
     // Add event to activity (avoid duplicates)
-    const activity = activitiesMap.get(activityId);
+    const activity = activitiesMap.get(groupingKey);
     const isDuplicate = activity.events.some(existingEvent => existingEvent.uuid === event.uuid);
     if (!isDuplicate) {
       activity.events.push(event);
@@ -128,6 +170,14 @@ function extractActiveActivitiesFromEvents(events: any[]): any[] {
     // Update attribute type if it differs from the current attribute type (might get updated from "unknown" to some value)
     if (activity.attributeType === 'unknown' && attributeType !== 'unknown') {
       activity.attributeType = attributeType;
+    }
+
+    // Update IDs if they were initially undefined
+    if (!activity.liveActivityId && liveActivityId) {
+      activity.liveActivityId = liveActivityId;
+    }
+    if (!activity.channelId && channelId) {
+      activity.channelId = channelId;
     }
 
     // Only update status to completed if this is an end event (dismissed or ended)
@@ -163,11 +213,9 @@ function useActivities(): LiveActivity[] {
     }
   });
 
-  console.log(activeActivities, 'activeActivities');
-
   // Create activities from the extracted active activities
   return activeActivities.map(activity => {
-    const { id, attributeType, events, status } = activity;
+    const { liveActivityId, channelId, activityType, attributeType, events, status } = activity;
 
     // Find specific events using type guards
     const updateTokenEvent = events.find(isLiveActivityUpdateTokenEvent);
@@ -185,14 +233,11 @@ function useActivities(): LiveActivity[] {
     // Get schema data for this attribute type
     const schemaDataForType = schemaData.get(attributeType);
 
-    // Extract type and broadcastChannelId from start event
-    const broadcastChannelId = startEvent?.payload?.ACPExtensionEventData?.channelID;
-    const activityType = broadcastChannelId ? 'broadcast' : 'unitary';
-
-
     return {
-      id,
-      name: attributeType, // Use attributeType as name for backward compatibility
+      id: liveActivityId || '',                // Use actual liveActivityID (may be empty for broadcast)
+      broadcastChannelId: channelId,           // Channel ID for broadcast activities
+      type: activityType,                      // Activity type from metadata
+      name: attributeType,                     // Use attributeType as name for backward compatibility
       attributes: attributeType,
       endEvent,
       endTime: endEvent?.timestamp,
@@ -205,9 +250,7 @@ function useActivities(): LiveActivity[] {
       pushToStartToken: pushToStartTokenEvent?.payload?.ACPExtensionEventData?.token,
       updateToken: updateTokenEvent?.payload?.ACPExtensionEventData?.token,
       updateEvents,
-      currentContentState,
-      type: activityType as 'unitary' | 'broadcast',
-      broadcastChannelId
+      currentContentState
     };
   });
 }

--- a/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
@@ -55,15 +55,15 @@ export interface LiveActivity {
 /**
  * Gets a unique key for a live activity that works for both unitary and broadcast types.
  * For unitary activities: uses the activity ID
- * For broadcast activities: uses the channel ID
+ * For broadcast activities: uses the channel ID + attribute type (to support multiple activity types per channel)
  * 
  * @param activity - The live activity
  * @returns A unique string key for the activity
  */
 export function getActivityKey(activity: LiveActivity): string {
-  // For broadcast: use channelId as the key
+  // For broadcast: use channelId + attributeType as the key (supports multiple types per channel)
   if (activity.type === 'broadcast' && activity.broadcastChannelId) {
-    return `broadcast:${activity.broadcastChannelId}`;
+    return `broadcast:${activity.broadcastChannelId}:${activity.name}`;
   }
   // For unitary: use id as the key
   if (activity.id) {
@@ -97,14 +97,16 @@ function extractActivityMetadata(event: any): {
   
   const activityType: 'unitary' | 'broadcast' = channelId ? 'broadcast' : 'unitary';
   
-  // Determine grouping key based on activity type
-  // For broadcast: group by channelID (required)
-  // For unitary: group by liveActivityID (required)
-  const groupingKey = activityType === 'broadcast' ? channelId : liveActivityId;
-  
   // For attributeType, try multiple possible locations
   const attributeType =
     eventData.attributeType || eventData.data?.attributeType || 'unknown';
+  
+  // Determine grouping key based on activity type
+  // For broadcast: group by channelID + attributeType (to support multiple activity types per channel)
+  // For unitary: group by liveActivityID (required)
+  const groupingKey = activityType === 'broadcast' 
+    ? `${channelId}:${attributeType}` 
+    : liveActivityId;
 
   if (!groupingKey) {
     return null;

--- a/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
@@ -6,6 +6,7 @@ import groupBy from 'lodash/groupBy';
 
 import { useMemo } from 'react';
 
+import { ACTIVITY_TYPE, ActivityType } from '../api/liveActivityApi';
 import { LIVE_ACTIVITIES_MATCHERS } from '../constants/matchers';
 import {
   isLiveActivityDismissedEvent,
@@ -48,7 +49,7 @@ export interface LiveActivity {
   examplePayload?: any;
   schema?: any;
   currentContentState?: any;
-  type?: 'unitary' | 'broadcast';
+  type?: ActivityType;
   broadcastChannelId?: string;
 }
 
@@ -62,12 +63,12 @@ export interface LiveActivity {
  */
 export function getActivityKey(activity: LiveActivity): string {
   // For broadcast: use channelId + attributeType as the key (supports multiple types per channel)
-  if (activity.type === 'broadcast' && activity.broadcastChannelId) {
-    return `broadcast:${activity.broadcastChannelId}:${activity.name}`;
+  if (activity.type === ACTIVITY_TYPE.BROADCAST && activity.broadcastChannelId) {
+    return `${ACTIVITY_TYPE.BROADCAST}:${activity.broadcastChannelId}:${activity.name}`;
   }
   // For unitary: use id as the key
   if (activity.id) {
-    return `unitary:${activity.id}`;
+    return `${ACTIVITY_TYPE.UNITARY}:${activity.id}`;
   }
   // Fallback (shouldn't happen in normal cases)
   return `unknown:${activity.name}:${activity.startTime || 'no-timestamp'}`;
@@ -83,7 +84,7 @@ function extractActivityMetadata(event: any): {
   liveActivityId?: string;
   channelId?: string;
   attributeType: string;
-  activityType: 'unitary' | 'broadcast';
+  activityType: ActivityType;
 } | null {
   const eventData = event.payload?.ACPExtensionEventData;
   if (!eventData) {
@@ -95,7 +96,7 @@ function extractActivityMetadata(event: any): {
   const channelId = eventData.channelID || eventData.data?.channelID;
   const liveActivityId = eventData.liveActivityID || eventData.data?.liveActivityID || eventData.activityId;
   
-  const activityType: 'unitary' | 'broadcast' = channelId ? 'broadcast' : 'unitary';
+  const activityType: ActivityType = channelId ? ACTIVITY_TYPE.BROADCAST : ACTIVITY_TYPE.UNITARY;
   
   // For attributeType, try multiple possible locations
   const attributeType =
@@ -104,7 +105,7 @@ function extractActivityMetadata(event: any): {
   // Determine grouping key based on activity type
   // For broadcast: group by channelID + attributeType (to support multiple activity types per channel)
   // For unitary: group by liveActivityID (required)
-  const groupingKey = activityType === 'broadcast' 
+  const groupingKey = activityType === ACTIVITY_TYPE.BROADCAST 
     ? `${channelId}:${attributeType}` 
     : liveActivityId;
 

--- a/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useActivities.ts
@@ -92,6 +92,9 @@ export function isUnitaryActivityKey(activityKey: string): boolean {
   return activityKey.startsWith(`${ACTIVITY_TYPE.UNITARY}:`);
 }
 
+export function splitActivityKeyParts(activityKey: string): string[] {
+  return activityKey.split(':');
+}
 /**
  * Parses an activity key to extract its components.
  * 
@@ -106,7 +109,7 @@ export function parseActivityKey(activityKey: string): {
 } {
   if (isBroadcastActivityKey(activityKey)) {
     // Format: "broadcast:channelId:attributeType"
-    const parts = activityKey.split(':');
+    const parts = splitActivityKeyParts(activityKey);
     return {
       type: ACTIVITY_TYPE.BROADCAST,
       channelId: parts[1],
@@ -116,7 +119,7 @@ export function parseActivityKey(activityKey: string): {
   
   if (isUnitaryActivityKey(activityKey)) {
     // Format: "unitary:liveActivityId"
-    const parts = activityKey.split(':');
+    const parts = splitActivityKeyParts(activityKey);
     return {
       type: ACTIVITY_TYPE.UNITARY,
       liveActivityId: parts[1]

--- a/packages/ui-plugins/live-activities/src/hooks/useActivityEvents.ts
+++ b/packages/ui-plugins/live-activities/src/hooks/useActivityEvents.ts
@@ -20,7 +20,9 @@ export function useActivityEvents(activityId?: string): LiveActivityEvent[] {
       combineAny([
         'payload.ACPExtensionEventData.liveActivityID',
         'payload.ACPExtensionEventData.data.liveActivityID',
-        'payload.ACPExtensionEventData.activityId'
+        'payload.ACPExtensionEventData.activityId',
+        'payload.ACPExtensionEventData.channelID',
+        'payload.ACPExtensionEventData.data.channelID',
       ])
     ],
     sorted: 'desc'

--- a/packages/ui-plugins/live-activities/src/i18n/features/activities.messages.ts
+++ b/packages/ui-plugins/live-activities/src/i18n/features/activities.messages.ts
@@ -235,6 +235,16 @@ export const activitiesMessages = defineMessages({
   noEventsAvailable: {
     id: 'activities.empty.noEventsAvailable',
     defaultMessage: 'No events available'
+  },
+  
+  // Activity types
+  typeUnitary: {
+    id: 'activities.type.unitary',
+    defaultMessage: 'Unitary'
+  },
+  typeBroadcast: {
+    id: 'activities.type.broadcast',
+    defaultMessage: 'Broadcast'
   }
 });
 

--- a/packages/ui-plugins/live-activities/src/i18n/features/activities.messages.ts
+++ b/packages/ui-plugins/live-activities/src/i18n/features/activities.messages.ts
@@ -245,6 +245,16 @@ export const activitiesMessages = defineMessages({
   typeBroadcast: {
     id: 'activities.type.broadcast',
     defaultMessage: 'Broadcast'
+  },
+  
+  // Filter labels
+  typeFilterLabel: {
+    id: 'activities.filter.type',
+    defaultMessage: 'Type'
+  },
+  statusFilterLabel: {
+    id: 'activities.filter.status',
+    defaultMessage: 'Status'
   }
 });
 

--- a/packages/ui-plugins/live-activities/src/i18n/features/activities.messages.ts
+++ b/packages/ui-plugins/live-activities/src/i18n/features/activities.messages.ts
@@ -64,6 +64,10 @@ export const activitiesMessages = defineMessages({
     id: 'activities.details.liveActivityId',
     defaultMessage: 'Live Activity ID'
   },
+  broadcastChannelId: {
+    id: 'activities.details.broadcastChannelId',
+    defaultMessage: 'Broadcast Channel ID'
+  },
   attributeSet: {
     id: 'activities.details.attributeSet',
     defaultMessage: 'Attribute Set'

--- a/packages/ui-plugins/live-activities/src/i18n/features/liveActivity.messages.ts
+++ b/packages/ui-plugins/live-activities/src/i18n/features/liveActivity.messages.ts
@@ -10,6 +10,10 @@ export const liveActivityMessages = defineMessages({
     id: 'liveActivity.launch.title',
     defaultMessage: 'Start Live Activity'
   },
+  launchNewLiveActivity: {
+    id: 'liveActivity.launch.new',
+    defaultMessage: 'Start a new live activity'
+  },
   selectActivity: {
     id: 'liveActivity.launch.select',
     defaultMessage: 'Select Live Activity'

--- a/packages/ui-plugins/live-activities/src/i18n/features/liveActivity.messages.ts
+++ b/packages/ui-plugins/live-activities/src/i18n/features/liveActivity.messages.ts
@@ -59,6 +59,32 @@ export const liveActivityMessages = defineMessages({
   eventTypeEnd: {
     id: 'liveActivity.eventType.end',
     defaultMessage: 'End'
+  },
+  
+  // Activity types
+  activityType: {
+    id: 'liveActivity.form.activityType',
+    defaultMessage: 'Activity Type'
+  },
+  activityTypeUnitary: {
+    id: 'liveActivity.activityType.unitary',
+    defaultMessage: 'Unitary'
+  },
+  activityTypeBroadcast: {
+    id: 'liveActivity.activityType.broadcast',
+    defaultMessage: 'Broadcast'
+  },
+  broadcastChannelId: {
+    id: 'liveActivity.form.broadcastChannelId',
+    defaultMessage: 'Broadcast Channel ID'
+  },
+  broadcastChannelIdPlaceholder: {
+    id: 'liveActivity.form.broadcastChannelId.placeholder',
+    defaultMessage: 'Enter broadcast channel ID'
+  },
+  broadcastChannelIdRequired: {
+    id: 'liveActivity.form.broadcastChannelId.required',
+    defaultMessage: 'Broadcast channel ID is required for broadcast type'
   }
 });
 

--- a/packages/ui-plugins/live-activities/src/types/liveActivityEvent.ts
+++ b/packages/ui-plugins/live-activities/src/types/liveActivityEvent.ts
@@ -5,8 +5,12 @@ export interface LiveActivityEvent extends Event {
     ACPExtensionEventName?: string;
     ACPExtensionEventData?: {
       liveActivityID?: string;
+      channelID?: string;
       data?: {
         liveActivityID?: string;
+        channelID?: string;
+        origin?: string;
+        type?: string;
       };
       activityId?: string;
       contentState?: any;

--- a/packages/ui-plugins/live-activities/src/types/liveActivityEvent.ts
+++ b/packages/ui-plugins/live-activities/src/types/liveActivityEvent.ts
@@ -6,11 +6,14 @@ export interface LiveActivityEvent extends Event {
     ACPExtensionEventData?: {
       liveActivityID?: string;
       channelID?: string;
+      attributeType?: string;
+      isLiveActivityUpdateTokenEvent?: boolean;
       data?: {
         liveActivityID?: string;
         channelID?: string;
         origin?: string;
         type?: string;
+        attributeType?: string;
       };
       activityId?: string;
       contentState?: any;

--- a/packages/ui-plugins/live-activities/src/utils/__tests__/eventProcessingUtils.test.ts
+++ b/packages/ui-plugins/live-activities/src/utils/__tests__/eventProcessingUtils.test.ts
@@ -4,6 +4,11 @@
 
 import { describe, it, expect } from 'vitest';
 import { processActivityEvents } from '../eventProcessingUtils';
+import { 
+  isBroadcastActivityKey, 
+  isUnitaryActivityKey, 
+  parseActivityKey 
+} from '../../hooks/useActivities';
 
 describe('Event Processing Utils - Broadcast Support', () => {
   let eventCounter = 0;
@@ -187,6 +192,70 @@ describe('Event Processing Utils - Broadcast Support', () => {
       const result = processActivityEvents(events, activityKey);
 
       expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('Activity Key Utility Functions', () => {
+    describe('isBroadcastActivityKey', () => {
+      it('should return true for broadcast activity keys', () => {
+        expect(isBroadcastActivityKey('broadcast:channel-123:FlightActivity')).toBe(true);
+        expect(isBroadcastActivityKey('broadcast:abc:xyz')).toBe(true);
+      });
+
+      it('should return false for non-broadcast activity keys', () => {
+        expect(isBroadcastActivityKey('unitary:activity-123')).toBe(false);
+        expect(isBroadcastActivityKey('unknown:something')).toBe(false);
+        expect(isBroadcastActivityKey('activity-123')).toBe(false);
+      });
+    });
+
+    describe('isUnitaryActivityKey', () => {
+      it('should return true for unitary activity keys', () => {
+        expect(isUnitaryActivityKey('unitary:activity-123')).toBe(true);
+        expect(isUnitaryActivityKey('unitary:abc-def-ghi')).toBe(true);
+      });
+
+      it('should return false for non-unitary activity keys', () => {
+        expect(isUnitaryActivityKey('broadcast:channel-123:FlightActivity')).toBe(false);
+        expect(isUnitaryActivityKey('unknown:something')).toBe(false);
+        expect(isUnitaryActivityKey('activity-123')).toBe(false);
+      });
+    });
+
+    describe('parseActivityKey', () => {
+      it('should parse broadcast activity keys correctly', () => {
+        const result = parseActivityKey('broadcast:channel-123:FlightActivity');
+        
+        expect(result.type).toBe('broadcast');
+        expect(result.channelId).toBe('channel-123');
+        expect(result.attributeType).toBe('FlightActivity');
+        expect(result.liveActivityId).toBeUndefined();
+      });
+
+      it('should parse unitary activity keys correctly', () => {
+        const result = parseActivityKey('unitary:activity-456');
+        
+        expect(result.type).toBe('unitary');
+        expect(result.liveActivityId).toBe('activity-456');
+        expect(result.channelId).toBeUndefined();
+        expect(result.attributeType).toBeUndefined();
+      });
+
+      it('should handle unknown/fallback keys', () => {
+        const result = parseActivityKey('some-random-id');
+        
+        expect(result.type).toBe('unknown');
+        expect(result.liveActivityId).toBe('some-random-id');
+        expect(result.channelId).toBeUndefined();
+        expect(result.attributeType).toBeUndefined();
+      });
+
+      it('should handle keys with colons in unknown format', () => {
+        const result = parseActivityKey('unknown:test:value');
+        
+        expect(result.type).toBe('unknown');
+        expect(result.liveActivityId).toBe('unknown:test:value');
+      });
     });
   });
 });

--- a/packages/ui-plugins/live-activities/src/utils/__tests__/eventProcessingUtils.test.ts
+++ b/packages/ui-plugins/live-activities/src/utils/__tests__/eventProcessingUtils.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for event processing utils - broadcast support
+ */
+
+import { describe, it, expect } from 'vitest';
+import { processActivityEvents } from '../eventProcessingUtils';
+
+describe('Event Processing Utils - Broadcast Support', () => {
+  let eventCounter = 0;
+  const createMockEvent = (id: string, channelId?: string, attributeType?: string): any => ({
+    uuid: `event-${id}-${eventCounter++}`, // Ensure unique UUIDs
+    timestamp: Date.now() + eventCounter, // Unique timestamps
+    type: 'com.adobe.eventType.messaging',
+    payload: {
+      ACPExtensionEventData: {
+        liveActivityID: channelId ? undefined : id,
+        channelID: channelId,
+        attributeType: attributeType || 'TestActivity',
+        data: {}
+      }
+    }
+  });
+
+  describe('processActivityEvents', () => {
+    it('should filter events by liveActivityID for unitary activities', () => {
+      const events = [
+        createMockEvent('activity-1'),
+        createMockEvent('activity-2'),
+        createMockEvent('activity-1'),
+        createMockEvent('activity-3')
+      ];
+
+      const activityKey = 'unitary:activity-1';
+      const result = processActivityEvents(events, activityKey);
+
+      expect(result).toHaveLength(2);
+      result.forEach(event => {
+        expect(event.payload?.ACPExtensionEventData?.liveActivityID).toBe('activity-1');
+      });
+    });
+
+    it('should filter events by channelID and attributeType for broadcast activities', () => {
+      const events = [
+        createMockEvent('1', 'channel-A', 'FoodActivity'),
+        createMockEvent('2', 'channel-A', 'FlightActivity'),
+        createMockEvent('3', 'channel-A', 'FoodActivity'),
+        createMockEvent('4', 'channel-B', 'FoodActivity')
+      ];
+
+      const activityKey = 'broadcast:channel-A:FoodActivity';
+      const result = processActivityEvents(events, activityKey);
+
+      expect(result).toHaveLength(2);
+      result.forEach(event => {
+        expect(event.payload?.ACPExtensionEventData?.channelID).toBe('channel-A');
+        expect(event.payload?.ACPExtensionEventData?.attributeType).toBe('FoodActivity');
+      });
+    });
+
+    it('should differentiate between same channel different activity types', () => {
+      const events = [
+        createMockEvent('1', 'shared-channel', 'Food'),
+        createMockEvent('2', 'shared-channel', 'Flight'),
+        createMockEvent('3', 'shared-channel', 'Food'),
+        createMockEvent('4', 'shared-channel', 'Flight')
+      ];
+
+      const foodKey = 'broadcast:shared-channel:Food';
+      const flightKey = 'broadcast:shared-channel:Flight';
+
+      const foodEvents = processActivityEvents(events, foodKey);
+      const flightEvents = processActivityEvents(events, flightKey);
+
+      expect(foodEvents).toHaveLength(2);
+      expect(flightEvents).toHaveLength(2);
+
+      foodEvents.forEach(event => {
+        expect(event.payload?.ACPExtensionEventData?.attributeType).toBe('Food');
+      });
+
+      flightEvents.forEach(event => {
+        expect(event.payload?.ACPExtensionEventData?.attributeType).toBe('Flight');
+      });
+    });
+
+    it('should deduplicate events by uuid', () => {
+      const duplicateEvent = createMockEvent('1', 'channel-X', 'TestActivity');
+      const events = [
+        duplicateEvent,
+        duplicateEvent,
+        duplicateEvent,
+        createMockEvent('2', 'channel-X', 'TestActivity')
+      ];
+
+      const activityKey = 'broadcast:channel-X:TestActivity';
+      const result = processActivityEvents(events, activityKey);
+
+      expect(result).toHaveLength(2);
+      const uuids = result.map(e => e.uuid);
+      expect(new Set(uuids).size).toBe(2);
+    });
+
+    it('should handle empty event array', () => {
+      const activityKey = 'unitary:activity-123';
+      const result = processActivityEvents([], activityKey);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle events without matching criteria', () => {
+      const events = [
+        createMockEvent('activity-1'),
+        createMockEvent('activity-2'),
+        createMockEvent('activity-3')
+      ];
+
+      const activityKey = 'unitary:activity-999';
+      const result = processActivityEvents(events, activityKey);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle fallback format (backward compatibility)', () => {
+      const events = [
+        createMockEvent('old-activity-id'),
+        createMockEvent('old-activity-id'),
+        createMockEvent('other-id')
+      ];
+
+      // Old format without prefix
+      const activityKey = 'old-activity-id';
+      const result = processActivityEvents(events, activityKey);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should handle events with missing ACPExtensionEventData', () => {
+      const events = [
+        createMockEvent('activity-1'),
+        {
+          uuid: 'invalid-event',
+          timestamp: Date.now(),
+          type: 'com.adobe.eventType.messaging',
+          payload: {}
+        },
+        createMockEvent('activity-1')
+      ];
+
+      const activityKey = 'unitary:activity-1';
+      const result = processActivityEvents(events, activityKey);
+
+      // Should only return valid events
+      expect(result).toHaveLength(2);
+    });
+
+    it('should handle broadcast events with data nested in data field', () => {
+      const events: any[] = [
+        {
+          uuid: 'event-nested-1',
+          timestamp: Date.now(),
+          type: 'com.adobe.eventType.messaging',
+          payload: {
+            ACPExtensionEventData: {
+              data: {
+                channelID: 'nested-channel',
+                attributeType: 'NestedActivity'
+              }
+            }
+          }
+        },
+        {
+          uuid: 'event-nested-2',
+          timestamp: Date.now(),
+          type: 'com.adobe.eventType.messaging',
+          payload: {
+            ACPExtensionEventData: {
+              data: {
+                channelID: 'nested-channel',
+                attributeType: 'NestedActivity'
+              }
+            }
+          }
+        }
+      ];
+
+      const activityKey = 'broadcast:nested-channel:NestedActivity';
+      const result = processActivityEvents(events, activityKey);
+
+      expect(result).toHaveLength(2);
+    });
+  });
+});
+

--- a/packages/ui-plugins/live-activities/src/utils/__tests__/eventProcessingUtils.test.ts
+++ b/packages/ui-plugins/live-activities/src/utils/__tests__/eventProcessingUtils.test.ts
@@ -9,6 +9,7 @@ import {
   isUnitaryActivityKey, 
   parseActivityKey 
 } from '../../hooks/useActivities';
+import { ACTIVITY_TYPE } from '../../constants/liveActivitiesConfig';
 
 describe('Event Processing Utils - Broadcast Support', () => {
   let eventCounter = 0;
@@ -226,7 +227,7 @@ describe('Event Processing Utils - Broadcast Support', () => {
       it('should parse broadcast activity keys correctly', () => {
         const result = parseActivityKey('broadcast:channel-123:FlightActivity');
         
-        expect(result.type).toBe('broadcast');
+        expect(result.type).toBe(ACTIVITY_TYPE.BROADCAST);
         expect(result.channelId).toBe('channel-123');
         expect(result.attributeType).toBe('FlightActivity');
         expect(result.liveActivityId).toBeUndefined();
@@ -235,7 +236,7 @@ describe('Event Processing Utils - Broadcast Support', () => {
       it('should parse unitary activity keys correctly', () => {
         const result = parseActivityKey('unitary:activity-456');
         
-        expect(result.type).toBe('unitary');
+        expect(result.type).toBe(ACTIVITY_TYPE.UNITARY);
         expect(result.liveActivityId).toBe('activity-456');
         expect(result.channelId).toBeUndefined();
         expect(result.attributeType).toBeUndefined();
@@ -244,7 +245,7 @@ describe('Event Processing Utils - Broadcast Support', () => {
       it('should handle unknown/fallback keys', () => {
         const result = parseActivityKey('some-random-id');
         
-        expect(result.type).toBe('unknown');
+        expect(result.type).toBe(ACTIVITY_TYPE.UNKNOWN);
         expect(result.liveActivityId).toBe('some-random-id');
         expect(result.channelId).toBeUndefined();
         expect(result.attributeType).toBeUndefined();
@@ -253,7 +254,7 @@ describe('Event Processing Utils - Broadcast Support', () => {
       it('should handle keys with colons in unknown format', () => {
         const result = parseActivityKey('unknown:test:value');
         
-        expect(result.type).toBe('unknown');
+        expect(result.type).toBe(ACTIVITY_TYPE.UNKNOWN);
         expect(result.liveActivityId).toBe('unknown:test:value');
       });
     });

--- a/packages/ui-plugins/live-activities/src/utils/eventProcessingUtils.ts
+++ b/packages/ui-plugins/live-activities/src/utils/eventProcessingUtils.ts
@@ -53,7 +53,7 @@ export function processActivityEvents(
       // For unitary: match liveActivityID
       return eventLiveActivityId === targetLiveActivityId;
     } else if (targetLiveActivityId) {
-      // Fallback: match any ID field
+      // Fallback: match any ID field for unknown activity type cases.
       return eventLiveActivityId === targetLiveActivityId || eventChannelId === targetLiveActivityId;
     }
     

--- a/packages/ui-plugins/live-activities/src/utils/eventProcessingUtils.ts
+++ b/packages/ui-plugins/live-activities/src/utils/eventProcessingUtils.ts
@@ -21,20 +21,56 @@ export interface TimeRange {
 
 /**
  * Process events for a specific Live Activity
+ * Supports composite keys for broadcast activities (broadcast:channelId:attributeType)
  */
 export function processActivityEvents(
   allEvents: LiveActivityEvent[],
-  activityId: string
+  activityKey: string
 ): LiveActivityEvent[] {
-  const filteredEvents = allEvents.filter(event => {
-    const eventLiveActivityID =
-      event.payload?.ACPExtensionEventData?.liveActivityID ||
-      event.payload?.ACPExtensionEventData?.data?.liveActivityID ||
-      event.payload?.ACPExtensionEventData?.activityId ||
-      event.payload?.ACPExtensionEventData?.channelID ||
-      event.payload?.ACPExtensionEventData?.data?.channelID
+  // Parse the activity key to determine type and identifiers
+  const isBroadcast = activityKey.startsWith('broadcast:');
+  const isUnitary = activityKey.startsWith('unitary:');
+  
+  let targetChannelId: string | undefined;
+  let targetAttributeType: string | undefined;
+  let targetLiveActivityId: string | undefined;
+  
+  if (isBroadcast) {
+    // Format: "broadcast:channelId:attributeType"
+    const parts = activityKey.split(':');
+    targetChannelId = parts[1];
+    targetAttributeType = parts[2];
+  } else if (isUnitary) {
+    // Format: "unitary:liveActivityId"
+    const parts = activityKey.split(':');
+    targetLiveActivityId = parts[1];
+  } else {
+    // Fallback: treat as direct ID (backward compatibility)
+    targetLiveActivityId = activityKey;
+  }
 
-    return eventLiveActivityID === activityId;
+  const filteredEvents = allEvents.filter(event => {
+    const eventData = event.payload?.ACPExtensionEventData;
+    
+    const eventChannelId = eventData?.channelID || eventData?.data?.channelID;
+    const eventLiveActivityId = 
+      eventData?.liveActivityID || 
+      eventData?.data?.liveActivityID || 
+      eventData?.activityId;
+    const eventAttributeType = eventData?.attributeType || eventData?.data?.attributeType;
+
+    if (isBroadcast && targetChannelId && targetAttributeType) {
+      // For broadcast: match both channelID and attributeType
+      return eventChannelId === targetChannelId && eventAttributeType === targetAttributeType;
+    } else if (isUnitary && targetLiveActivityId) {
+      // For unitary: match liveActivityID
+      return eventLiveActivityId === targetLiveActivityId;
+    } else if (targetLiveActivityId) {
+      // Fallback: match any ID field
+      return eventLiveActivityId === targetLiveActivityId || eventChannelId === targetLiveActivityId;
+    }
+    
+    return false;
   });
 
   // Deduplicate by uuid to avoid duplicate events

--- a/packages/ui-plugins/live-activities/src/utils/eventProcessingUtils.ts
+++ b/packages/ui-plugins/live-activities/src/utils/eventProcessingUtils.ts
@@ -30,7 +30,9 @@ export function processActivityEvents(
     const eventLiveActivityID =
       event.payload?.ACPExtensionEventData?.liveActivityID ||
       event.payload?.ACPExtensionEventData?.data?.liveActivityID ||
-      event.payload?.ACPExtensionEventData?.activityId;
+      event.payload?.ACPExtensionEventData?.activityId ||
+      event.payload?.ACPExtensionEventData?.channelID ||
+      event.payload?.ACPExtensionEventData?.data?.channelID
 
     return eventLiveActivityID === activityId;
   });

--- a/packages/ui-plugins/live-activities/src/utils/eventProcessingUtils.ts
+++ b/packages/ui-plugins/live-activities/src/utils/eventProcessingUtils.ts
@@ -1,6 +1,6 @@
-import { combineAny } from '@adobe/griffon-toolkit';
 import { EVENT_CONFIG } from '../constants/liveActivitiesConfig';
 import { LiveActivityEvent } from '../types/liveActivityEvent';
+import { isBroadcastActivityKey, isUnitaryActivityKey, parseActivityKey } from '../hooks/useActivities';
 
 export interface EventStatistics {
   total: number;
@@ -27,27 +27,14 @@ export function processActivityEvents(
   allEvents: LiveActivityEvent[],
   activityKey: string
 ): LiveActivityEvent[] {
-  // Parse the activity key to determine type and identifiers
-  const isBroadcast = activityKey.startsWith('broadcast:');
-  const isUnitary = activityKey.startsWith('unitary:');
+  // Parse the activity key using utility functions
+  const isBroadcast = isBroadcastActivityKey(activityKey);
+  const isUnitary = isUnitaryActivityKey(activityKey);
+  const parsedKey = parseActivityKey(activityKey);
   
-  let targetChannelId: string | undefined;
-  let targetAttributeType: string | undefined;
-  let targetLiveActivityId: string | undefined;
-  
-  if (isBroadcast) {
-    // Format: "broadcast:channelId:attributeType"
-    const parts = activityKey.split(':');
-    targetChannelId = parts[1];
-    targetAttributeType = parts[2];
-  } else if (isUnitary) {
-    // Format: "unitary:liveActivityId"
-    const parts = activityKey.split(':');
-    targetLiveActivityId = parts[1];
-  } else {
-    // Fallback: treat as direct ID (backward compatibility)
-    targetLiveActivityId = activityKey;
-  }
+  const targetChannelId = parsedKey.channelId;
+  const targetAttributeType = parsedKey.attributeType;
+  const targetLiveActivityId = parsedKey.liveActivityId;
 
   const filteredEvents = allEvents.filter(event => {
     const eventData = event.payload?.ACPExtensionEventData;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

🎯 Add Broadcast Live Activity Support and UX Improvements
📝 Summary
This PR adds comprehensive support for Broadcast Live Activities alongside the existing Unitary type, along with significant UX improvements and bug fixes. Users can now start, update, and manage both types of Live Activities seamlessly.


✨ Key Features
🔄 Broadcast Live Activity Support

1. Dual Activity Types: Added support for both unitary and broadcast Live Activity types
2. Type Selection: Radio button interface to choose between Unitary and Broadcast when starting activities
3. Broadcast Channel ID: Mandatory input field for broadcast activities with validation
4. Payload Generation: Automatic inclusion of type and channelID in push payloads for broadcast activities
5. Token Management: Smart token handling - broadcast activities don't require update tokens
6. Channel Reuse: Support for reusing the same broadcast channel for multiple activity instances over time
7. Multi-Type Support: Multiple activity types can share the same broadcast channel (e.g., Food and Flight on channel "X")


🎨 UI/UX Improvements

1. Type Badges: Visual pill badges on activity cards showing "Broadcast" or "Unitary" type
2. Filter Dropdowns: Converted type and status filters to dropdown menus for better space efficiency
3. Smart Button Layout:  
  1. Compact circular (+) button when activities exist (saves vertical space)
  2. Full "Start Activity" button with icon when no activities exist
  3. Moved button into ActivityList header to prevent content shifting
4. Enhanced Activity Cards: Better visual hierarchy and information display for both activity types


🐛 Bug Fixes

1. Fixed broadcast activity selection bug when id field was empty
2. Resolved event filtering issues for broadcast activities
3. Fixed payload generation to preserve user custom fields while adding broadcast-specific fields
5. Corrected type detection logic based on channelID presence
6. Fixed activity status determination to support channel reuse

📊 Display Improvements

1. Push-to-Start Tokens: Display tokens per activity type for better clarity
2. Activity Identification:
  1. Unitary: Shows liveActivityID
  2. Broadcast: Shows channelID + attributeType
3. Event Grouping: Proper event association for broadcast activities using composite keys


📸 Visual Changes

- Before: Single header bar taking vertical space, no type differentiation
- After: Compact button integrated into list header
- Clear type badges on activity cards
- Dropdown filters for type and status
- Broadcast activities show channel ID + activity type
- Send Update button is enabled even if activity completed giving a real world test as we do not have any limitation on api as well. (AS DISCUSSED)

🎯 Use Cases Supported
✅ Start and manage unitary activities (existing functionality preserved)
✅ Start broadcast activities with channel ID
✅ Multiple activity types on same broadcast channel
✅ Reuse broadcast channel for new activities after previous ones end
✅ Filter activities by type (all/unitary/broadcast)
✅ Update broadcast activities without update tokens
✅ Visual differentiation between activity types


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
